### PR TITLE
Setup travis ci (Fixes #2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+addons:
+  postgresql: "9.3"
+
+services:
+  - postgresql
+
+language: python
+
+python:
+  - "2.7"
+
+cache: pip
+
+git:
+  submodules: false
+
+before_install:
+  - echo -e "machine github.com\n  login simplified-bot\n  password $CI_USER_PASSWORD" >> ~/.netrc
+  - git submodule update --init --recursive
+
+install:
+  - pip install -r requirements.txt
+  - cp config.json.sample config.json
+  - export SIMPLIFIED_CONFIGURATION_FILE="$TRAVIS_BUILD_DIR/config.json"
+
+before_script:
+  - psql -c 'create user simplified_test;' -U postgres
+  - psql -c 'create database simplified_metadata_test;' -U postgres
+  - psql -c 'grant all privileges on database simplified_metadata_test to simplified_test;' -U postgres
+
+script: ./test

--- a/config.json.sample
+++ b/config.json.sample
@@ -1,0 +1,18 @@
+{
+    "gutenberg_illustrated_binary_path" : "",
+    "data_directory" : "",
+    "policies" : {
+        
+    },
+    "integrations" : {
+    	"Postgres" : {
+    	    "test_url" : "postgres://simplified_test:test@localhost:5432/simplified_metadata_test"
+    	},
+
+    	"Content Server": {
+    	},
+        
+    	"S3" : {
+    	}
+    }
+}


### PR DESCRIPTION
This setup mimics NYPL-Simplified/content_server#28, allowing tests to run on Travis CI.

It won't be particularly helpful until #9 is resolved, though, since tests aren't currently passing. Setup also can't be arranged until the repo is public.
