### PR TITLE
Fix VIAF tests

### DIFF
--- a/tests/test_viaf.py
+++ b/tests/test_viaf.py
@@ -109,17 +109,12 @@ class TestNameParser(DatabaseTest):
         xml = self.sample_data("howard_j_j.xml")
         name = "Howard, J. J."
         contributor, new = self._contributor(name)
-        viaf, display_name, family_name, sort_name, wikipedia_name = self.parser.parse(
+        viaf, display_name, family_name, sort_name, wikipedia_name = self.parser.parse_multiple(
             xml, working_sort_name=name)
-        # TODO: This is just broken. We need to make this work,
-        # preferably in a way that lets the (very similar) "Samuel
-        # Clemens" case also work.
 
-        # We can't find a VIAF number. The display name and family name
-        # are obtained through heuristics.
         eq_(None, viaf)
-        eq_("J. J. Howard", display_name)
-        eq_("Howard", family_name)
+        eq_(None, display_name)
+        eq_(None, family_name)
         eq_(None, wikipedia_name)
 
     def test_multiple_results_with_success(self):


### PR DESCRIPTION
Okay, so, there was a lot to hate about this J. J. Howard test:
1. It was using `#parse` when it should have been using `#parse_multiple`. Tsk tsk, test!
2. It was expecting VIAF Parser to return results it simply didn't have.
3. If the VIAF Parser did comply with this test's expectations, it would be in direct opposition with the expectations of the currently passing `#test_multiple_results_with_viaf_number_but_no_name`

I can make this work and adjust the test on line 130, but I'm dubious about the VIAF parser guessing about names. Should that work go in the contributor itself? The metadata layer? I'm going to investigate.

Fixes #9.
