### PR TITLE
Use https submodule link to allow Travis setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "core"]
 	path = core
-	url = git@github.com:NYPL/Simplified-server-core.git
+	url = https://github.com/NYPL/Simplified-server-core.git


### PR DESCRIPTION
The Travis build is still broken because scipy & scikit-learn do not play nicely (see: #12), but this will help it work when that's resolved.
