### PR TITLE
Update CoverageProviders and fix IdentifierResolutionMonitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
-bin/
 build/
 develop-eggs/
 dist/

--- a/content_cafe.py
+++ b/content_cafe.py
@@ -30,14 +30,14 @@ from core.util.summary import SummaryEvaluator
 class ContentCafeCoverageProvider(CoverageProvider):
     def __init__(self, _db):
         self._db = _db
+        self.input_identifier_types = [Identifier.ISBN]
+        self.output_source = DataSource.lookup(_db, DataSource.CONTENT_CAFE)
         self.mirror = ContentCafeCoverImageMirror(self._db)
         self.content_cafe = ContentCafeAPI(self._db, self.mirror)
-        input_identifier_types = [Identifier.ISBN]
-        output_source = DataSource.CONTENT_CAFE
 
         super(ContentCafeCoverageProvider, self).__init__(
             "Content Cafe Coverage Provider",
-            input_identifier_types, output_source,
+            self.input_identifier_types, self.output_source,
             workset_size=25)
 
     def process_item(self, identifier):

--- a/content_cafe.py
+++ b/content_cafe.py
@@ -9,7 +9,10 @@ from suds.client import Client as SudsClient
 
 from sqlalchemy import and_
 from core.config import Configuration
-from core.coverage import CoverageProvider
+from core.coverage import (
+    CoverageProvider,
+    CoverageFailure,
+)
 from core.model import (
     DataSource,
     Hyperlink,

--- a/content_server.py
+++ b/content_server.py
@@ -13,7 +13,7 @@ from core.coverage import (
 )
 
 class ContentServerException(Exception):
-    # Raised when the ContentServer can't connect
+    # Raised when the ContentServer can't connect or returns bad data
     pass
 
 class ContentServerCoverageProvider(CoverageProvider):

--- a/content_server.py
+++ b/content_server.py
@@ -1,0 +1,75 @@
+from core.config import Configuration
+from core.model import (
+    DataSource,
+    Identifier,
+)
+from core.opds_import import (
+    SimplifiedOPDSLookup,
+    OPDSImporter,
+)
+from core.coverage import (
+    CoverageProvider,
+    CoverageFailure,
+)
+
+class ContentServerException(Exception):
+    # Raised when the ContentServer can't connect
+    pass
+
+class ContentServerCoverageProvider(CoverageProvider):
+    """Checks the OA Content Server for Records"""
+
+    CONTENT_SERVER_RETURNED_ERROR = "OA Content Server returned error"
+    CONTENT_SERVER_RETURNED_WRONG_CONTENT_TYPE = "Content Server served \
+            unhandleable media type"
+
+    def __init__(self, _db):
+        self._db = _db
+        content_server_url = Configuration.integration_url(
+            Configuration.CONTENT_SERVER_INTEGRATION, required=True)
+        self.content_server = SimplifiedOPDSLookup(content_server_url)
+        self.importer = OPDSImporter(self._db, DataSource.OA_CONTENT_SERVER)
+        input_identifier_types = [Identifier.GUTENBERG_ID]
+        output_source = DataSource.OA_CONTENT_SERVER
+        super(ContentServerCoverageProvider, self).__init__(_db,
+                "OA Content Server Coverage Provider",
+                input_identifier_types, output_source, workset_size=10)
+
+    def process_item(self, identifier):
+        response = self.content_server.lookup(identifier)
+        self.check_response_for_errors(response)
+
+        editions, messages = self.importer.import_from_feed(response)
+        for edition in editions:
+            # Check that this identifier's edition was imported
+            # and return it as a success if so.
+            edition_identifier = edition.primary_identifier
+            if edition_identifier == identifier:
+                return identifier
+        for message_identifier, (status_code, exception) in messages.items():
+            # Return messages as CoverageFailures.
+            if message_identifier == identifier:
+                if status_code == 200:
+                    exception = "OA Content Server returned success, but \
+                            nothing was imported"
+                    return CoverageFailure(self, identifier, exception)
+                return CoverageFailure(self, identifier, exception)
+
+        exception = "404: Identifier %r was not found in %s" % (identifier,
+                self.service_name)
+        return CoverageFailure(self, identifier, exception)
+
+    def check_response_for_errors(self, response):
+        """Raises a server error if a response is not a success.
+
+        TODO: This probably doesn't go here.
+        """
+        if response.status_code != 200:
+            raise ContentServerException(self.CONTENT_SERVER_RETURNED_ERROR)
+
+        content_type = response.headers['content-type']
+        if not content_type.startswith("application/atom+xml"):
+            raise ContentServerException(
+                self.CONTENT_SERVER_RETURNED_WRONG_CONTENT_TYPE % (
+                content_type)
+            )

--- a/monitor.py
+++ b/monitor.py
@@ -25,6 +25,7 @@ from core.overdrive import (
     OverdriveAPI,
     OverdriveBibliographicCoverageProvider,
 )
+from core.threem import ThreeMBibliographicCoverageProvider
 from core.opds_import import SimplifiedOPDSLookup
 from core.classifier import Classifier
 from core.monitor import (
@@ -52,11 +53,7 @@ from content_cafe import (
     ContentCafeAPI,
 )
 from overdrive import OverdriveCoverImageMirror
-from threem import (
-    ThreeMBibliographicMonitor,
-    ThreeMCoverImageMirror,
-)
-
+from threem import ThreeMCoverImageMirror
 from gutenberg import (
     OCLCClassifyMonitor,
     OCLCMonitorForGutenberg,
@@ -141,7 +138,7 @@ class IdentifierResolutionMonitor(Monitor):
         self.create_missing_unresolved_identifiers()
 
         self.overdrive_coverage_provider = OverdriveBibliographicCoverageProvider(self._db)
-        self.threem_coverage_provider = ThreeMBibliographicMonitor(self._db)
+        self.threem_coverage_provider = ThreeMBibliographicCoverageProvider(self._db)
         self.content_cafe_provider = ContentCafeCoverageProvider(self._db)
 
         providers_need_resolving = [

--- a/monitor.py
+++ b/monitor.py
@@ -238,6 +238,8 @@ class IdentifierResolutionMonitor(Monitor):
                     successes.append(unresolved_identifier)
             except requests.exceptions.ConnectionError:
                 return 500, self.LICENSE_SOURCE_NOT_ACCESSIBLE
+            except ContentServerException as e:
+                return 500, repr(e)
             except Exception as e:
                 failure = self.process_failure(
                     unresolved_identifier,

--- a/monitor.py
+++ b/monitor.py
@@ -46,6 +46,10 @@ from core.model import (
     Work,
 )
 from core.opds_import import DetailedOPDSImporter
+from core.coverage import (
+    CoverageProvider,
+    CoverageFailure,
+)
 
 from mirror import ImageScaler
 from content_cafe import (

--- a/monitor.py
+++ b/monitor.py
@@ -21,7 +21,10 @@ from fast import (
 
 from threem import ThreeMAPI
 from core.config import Configuration
-from core.overdrive import OverdriveAPI
+from core.overdrive import (
+    OverdriveAPI,
+    OverdriveBibliographicCoverageProvider,
+)
 from core.opds_import import SimplifiedOPDSLookup
 from core.classifier import Classifier
 from core.monitor import (
@@ -48,10 +51,7 @@ from content_cafe import (
     ContentCafeCoverageProvider,
     ContentCafeAPI,
 )
-from overdrive import (
-    OverdriveBibliographicMonitor,
-    OverdriveCoverImageMirror,
-)
+from overdrive import OverdriveCoverImageMirror
 from threem import (
     ThreeMBibliographicMonitor,
     ThreeMCoverImageMirror,
@@ -140,7 +140,7 @@ class IdentifierResolutionMonitor(Monitor):
     def run_once(self, start, cutoff):
         self.create_missing_unresolved_identifiers()
 
-        self.overdrive_coverage_provider = OverdriveBibliographicMonitor(self._db)
+        self.overdrive_coverage_provider = OverdriveBibliographicCoverageProvider(self._db)
         self.threem_coverage_provider = ThreeMBibliographicMonitor(self._db)
         self.content_cafe_provider = ContentCafeCoverageProvider(self._db)
 

--- a/monitor.py
+++ b/monitor.py
@@ -248,6 +248,8 @@ class IdentifierResolutionMonitor(Monitor):
                     failures.append(failure)
                 else:
                     successes.append(unresolved_identifier)
+            except requests.exceptions.ConnectionError:
+                return 500, self.LICENSE_SOURCE_NOT_ACCESSIBLE
             except Exception as e:
                 failure = self.process_failure(
                     unresolved_identifier,

--- a/monitor.py
+++ b/monitor.py
@@ -26,7 +26,6 @@ from core.overdrive import (
     OverdriveBibliographicCoverageProvider,
 )
 from core.threem import ThreeMBibliographicCoverageProvider
-from core.opds_import import SimplifiedOPDSLookup
 from core.classifier import Classifier
 from core.monitor import (
     Monitor,
@@ -45,11 +44,7 @@ from core.model import (
     UnresolvedIdentifier,
     Work,
 )
-from core.opds_import import DetailedOPDSImporter
-from core.coverage import (
-    CoverageProvider,
-    CoverageFailure,
-)
+from core.coverage import CoverageFailure
 
 from mirror import ImageScaler
 from content_cafe import (
@@ -63,7 +58,6 @@ from gutenberg import (
     OCLCClassifyMonitor,
     OCLCMonitorForGutenberg,
 )
-from content_cafe import ContentCafeAPI
 from oclc import LinkedDataCoverageProvider
 from viaf import VIAFClient
 
@@ -73,9 +67,6 @@ class IdentifierResolutionMonitor(Monitor):
     Or (for ISBNs) just a bunch of Resources.
     """
 
-    LICENSE_SOURCE_RETURNED_ERROR = "Underlying license source returned error."
-    LICENSE_SOURCE_RETURNED_WRONG_CONTENT_TYPE = (
-        "Underlying license source served unhandlable media type (%s).")
     LICENSE_SOURCE_NOT_ACCESSIBLE = (
         "Could not access underlying license source over the network.")
     UNKNOWN_FAILURE = "Unknown failure."
@@ -83,9 +74,6 @@ class IdentifierResolutionMonitor(Monitor):
     def __init__(self, _db):
         super(IdentifierResolutionMonitor, self).__init__(
             _db, "Identifier Resolution Manager", interval_seconds=5)
-        content_server_url = Configuration.integration_url(
-            Configuration.CONTENT_SERVER_INTEGRATION, required=True)
-        self.content_server = SimplifiedOPDSLookup(content_server_url)
 
     def create_missing_unresolved_identifiers(self):
         """Find any Identifiers that should have LicensePools but don't,

--- a/overdrive.py
+++ b/overdrive.py
@@ -29,40 +29,6 @@ from core.model import (
 from core.monitor import Monitor
 from core.util import LanguageCodes
 
-class OverdriveBibliographicMonitor(CoverageProvider):
-    """Fill in bibliographic metadata for Overdrive records."""
-
-    cls_log = logging.getLogger("Overdrive Bibliographic Monitor")
-
-    def __init__(self, _db):
-        self._db = _db
-        self.overdrive = OverdriveAPI(self._db)
-        self.input_source = DataSource.lookup(_db, DataSource.OVERDRIVE)
-        self.output_source = DataSource.lookup(_db, DataSource.OVERDRIVE)
-        super(OverdriveBibliographicMonitor, self).__init__(
-            "Overdrive Bibliographic Monitor",
-            self.input_source, self.output_source)
-
-    def process_edition(self, edition):
-        identifier = edition.primary_identifier
-        info = self.overdrive.metadata_lookup(identifier)
-        if info.get('errorCode') == 'NotFound':
-            # TODO: We need to represent some kind of permanent failure.
-            raise Exception("ID not recognized by Overdrive")
-        metadata = OverdriveRepresentationExtractor.book_info_to_metadata(
-            info
-        )
-        if not metadata:
-            raise Exception("Could not extract metadata from Overdrive data: %r" % info)
-        metadata.apply(edition)
-
-    media_type_for_overdrive_type = {
-        "ebook-pdf-adobe" : "application/pdf",
-        "ebook-pdf-open" : "application/pdf",
-        "ebook-epub-adobe" : "application/epub+zip",
-        "ebook-epub-open" : "application/epub+zip",
-    }
-        
 class OverdriveCoverImageMirror(CoverImageMirror):
     """Downloads images from Overdrive and writes them to disk."""
 

--- a/scripts.py
+++ b/scripts.py
@@ -51,12 +51,6 @@ class WorkPresentationCalculationScript(WorkProcessingScript):
         return q
 
 
-class IdentifierResolutionScript(Script):
-
-    def run(self):
-        IdentifierResolutionMonitor(self._db).run(self._db)
-
-
 class CoverImageMirrorScript(Script):
     """This is not needed in normal usage, but it's useful to have it
     around in case the covers get screwed up, or to do intial

--- a/scripts.py
+++ b/scripts.py
@@ -50,17 +50,11 @@ class WorkPresentationCalculationScript(WorkProcessingScript):
             q = q.filter(Work.fiction==None).filter(Work.audience==None)
         return q
 
+
 class IdentifierResolutionScript(Script):
 
-
     def run(self):
-        content_server_url = Configuration.integration_url(
-            Configuration.CONTENT_SERVER_INTEGRATION, required=True)
-        content_server = SimplifiedOPDSLookup(content_server_url)
-        overdrive = OverdriveAPI(self._db)
-        threem = ThreeMAPI(self._db)
-        IdentifierResolutionMonitor(content_server, overdrive, threem).run(
-            self._db)
+        IdentifierResolutionMonitor(self._db).run(self._db)
 
 
 class CoverImageMirrorScript(Script):

--- a/threem.py
+++ b/threem.py
@@ -1,57 +1,7 @@
 from nose.tools import set_trace
 
-import isbnlib
-import datetime
-from lxml import etree
-
 from mirror import CoverImageMirror
-from core.coverage import CoverageProvider
-
-from core.model import (
-    Contributor,
-    DataSource,
-    Edition,
-    Hyperlink,
-    Identifier,
-    Subject,
-)
-from core.coverage import CoverageProvider
-from core.monitor import Monitor
-from core.util.xmlparser import XMLParser
-from core.threem import ThreeMAPI
-from core.util import LanguageCodes
-
-
-class ThreeMBibliographicMonitor(CoverageProvider):
-    """Fill in bibliographic metadata for 3M records."""
-
-    def __init__(self, _db,
-                 account_id=None, library_id=None, account_key=None,
-                 batch_size=1):
-        self._db = _db
-        self.api = ThreeMAPI(_db, account_id, library_id, account_key)
-        self.input_source = DataSource.lookup(_db, DataSource.THREEM)
-        self.output_source = DataSource.lookup(_db, DataSource.THREEM)
-        super(ThreeMBibliographicMonitor, self).__init__(
-            "3M Bibliographic Monitor",
-            self.input_source, self.output_source)
-        self.current_batch = []
-        self.batch_size=batch_size
-
-    def process_edition(self, edition):
-        by_identifier = self.api.get_bibliographic_info_for([edition])
-        [(edition, metadata)] = by_identifier.values()
-        metadata.apply(
-            edition,
-            replace_identifiers=True,
-            replace_subjects=True,
-            replace_contributions=True,
-            replace_links=True,
-            replace_formats=True,
-        )
-        self.log.info("Processed edition %r", edition)
-        return True
-        
+from core.model import DataSource
 
 class ThreeMCoverImageMirror(CoverImageMirror):
     """Downloads images from 3M and writes them to disk."""


### PR DESCRIPTION
This allows the IdentifierResolutionMonitor to interact with the new identifier-focused format of CoverageProviders to ensure coverage, updating the `ContentCafeCoverageProvider` and creating a coverage provider for the OA Content Server in the meantime.

Requires NYPL-Simplified/server_core#56. Fixes #21.

Next steps include:
- Confirming that the OCLC Coverage Providers function as expected
- Tossing all relevant Coverage Providers into the list
- Running UnresolvedIdentifiers through each provider individually and marking them presentation-ready as coverage is established.