### PR TITLE
Fix oclc coverage providers

### DIFF
--- a/gutenberg.py
+++ b/gutenberg.py
@@ -1,8 +1,14 @@
 import re
 from nose.tools import set_trace
 
-from core.coverage import CoverageProvider
-from core.model import DataSource
+from core.coverage import (
+    CoverageProvider,
+    CoverageFailure,
+)
+from core.model import (
+    DataSource,
+    Identifier,
+)
 from oclc import (
     OCLCClassifyAPI,
     OCLCXMLParser,
@@ -19,43 +25,54 @@ class OCLCClassifyCoverageProvider(CoverageProvider):
     # OCLC has trouble recognizing non-alphanumerics in titles,
     # especially colons.
     NON_TITLE_SAFE = re.compile("[^\w\-' ]", re.UNICODE)
-    
-    def __init__(self, _db, input_source_name):
+
+    def __init__(self, _db):
         self._db = _db
-        self.oclc_classify = OCLCClassifyAPI(self._db)
-        input_source = DataSource.lookup(self._db, input_source_name)
+        self.api = OCLCClassifyAPI(self._db)
+        input_identifier_types = [
+            Identifier.THREEM_ID, Identifier.GUTENBERG_ID, Identifier.URI
+        ]
         output_source = DataSource.lookup(self._db, DataSource.OCLC)
         super(OCLCClassifyCoverageProvider, self).__init__(
-            "OCLC Classify Monitor for %s" % input_source.name,
-            input_source, output_source)
+            "OCLC Classify Coverage Provider", input_identifier_types,
+            output_source)
 
     def oclc_safe_title(self, title):
         return self.NON_TITLE_SAFE.sub("", title)
 
-    def title_and_author(self, book):
-        title = self.oclc_safe_title(book.title)
+    def get_edition_info(self, edition):
+        """Returns the API-safe title, author(s), and language for an
+        edition
+        """
+        title = self.oclc_safe_title(edition.title)
 
-        authors = book.author_contributors
+        authors = edition.author_contributors
         if len(authors) == 0:
             author = ''
         else:
             author = authors[0].name
-        return title, author
 
-    def process_edition(self, book):
-        title, author = self.title_and_author(book)
-        language = book.language
+        language = edition.language
 
+        # Log the info
         def _f(s):
             if not s:
                 return ''
             if isinstance(s, unicode):
                 return s.encode("utf8")
             return s
-        self.log.info('%s "%s" "%s" %r', _f(book.primary_identifier.identifier), _f(title), _f(author), _f(language))
-        # Perform a title/author lookup
-        xml = self.oclc_classify.lookup_by(title=title, author=author)
+        self.log.info(
+            '%s "%s" "%s" %r', _f(edition.primary_identifier.identifier),
+            _f(title), _f(author), _f(language)
+        )
 
+        return title, author, language
+
+    def parse_edition_data(self, xml, edition, title, language):
+        """Transforms the OCLC XML files into usable bibliographic records,
+        including making additional API calls as necessary.
+        """
+        parser = OCLCXMLParser()
         # For now, the only restriction we apply is the language
         # restriction. If we know that a given OCLC record is in a
         # different language from this record, there's no need to
@@ -64,49 +81,52 @@ class OCLCClassifyCoverageProvider(CoverageProvider):
         # works.
         restrictions = dict(language=language,
                             title=title,
-                            authors=book.author_contributors)
+                            authors=edition.author_contributors)
+        # These representation types shouldn't occur, but if they do there's
+        # either nothing we need to do about them or nothing we can do.
+        ignored_representation_types = [
+            parser.NOT_FOUND_STATUS, parser.INVALID_INPUT_STATUS,
+            parser.NO_INPUT_STATUS
+        ]
 
         # Turn the raw XML into some number of bibliographic records.
-        representation_type, records = OCLCXMLParser.parse(
-            self._db, xml, **restrictions)
+        representation_type, records = parser.parse(
+            self._db, xml, **restrictions
+        )
 
-        if representation_type == OCLCXMLParser.MULTI_WORK_STATUS:
+        if representation_type == parser.MULTI_WORK_STATUS:
             # `records` contains a bunch of SWIDs, not
             # Editions. Do another lookup to turn each SWID
             # into a set of Editions.
             swids = records
             records = []
             for swid in swids:
-                swid_xml = self.oclc_classify.lookup_by(wi=swid)
-                representation_type, editions = OCLCXMLParser.parse(
-                    self._db, swid_xml, **restrictions)
-
-                if representation_type == OCLCXMLParser.SINGLE_WORK_DETAIL_STATUS:
+                swid_xml = self.api.lookup_by(wi=swid)
+                representation_type, editions = parser.parse(
+                    self._db, swid_xml, **restrictions
+                )
+                if representation_type == parser.SINGLE_WORK_DETAIL_STATUS:
                     records.extend(editions)
-                elif representation_type == OCLCXMLParser.NOT_FOUND_STATUS:
-                    # This shouldn't happen, but if it does,
-                    # it's not a big deal. Just do nothing.
-                    pass
-                elif representation_type == OCLCXMLParser.INVALID_INPUT_STATUS:
-                    # This also shouldn't happen, but if it does,
-                    # there's nothing we can do.
-                    pass                    
-                elif representation_type == OCLCXMLParser.NO_INPUT_STATUS:
-                    # This _really_ shouldn't happen, but if it does,
-                    # there's nothing we can do.                    
+                elif representation_type in ignored_representation_types:
                     pass
                 else:
-                    raise IOError("Got unexpected representation type from lookup: %s" % representation_type)
-        # Connect the Gutenberg book to the OCLC works looked up by
-        # title/author. Hopefully we can also connect the Gutenberg book
-        # to an author who has an LC and VIAF.
+                    raise IOError(
+                        "Got unexpected representation type from \
+                        lookup: %s" % representation_type
+                    )
+        return records
 
+    def merge_contributors(self, edition, records):
+        """Connect the Gutenberg book to the OCLC works looked up by
+        title/author. Hopefully we can also connect the Gutenberg book
+        to an author who has an LC and VIAF.
+        """
         # First, find any authors associated with this book that
         # have not been given VIAF or LC IDs.
         gutenberg_authors_to_merge = [
-            x for x in book.author_contributors if not x.viaf or not x.lc
+            x for x in edition.author_contributors if not x.viaf or not x.lc
         ]
-        gutenberg_names = set([x.name for x in book.author_contributors])
+        gutenberg_names = set([x.name for x in edition.author_contributors])
         for r in records:
             if gutenberg_authors_to_merge:
                 oclc_names = set([x.name for x in r.author_contributors])
@@ -117,7 +137,7 @@ class OCLCClassifyCoverageProvider(CoverageProvider):
                     # Gutenberg author into its OCLC equivalent.
                     for gutenberg_author in gutenberg_authors_to_merge:
                         oclc_authors = [x for x in r.author_contributors
-                                        if x.name==gutenberg_author.name]
+                                        if x.name == gutenberg_author.name]
                         if len(oclc_authors) == 1:
                             oclc_author = oclc_authors[0]
                             if oclc_author != gutenberg_author:
@@ -127,10 +147,25 @@ class OCLCClassifyCoverageProvider(CoverageProvider):
 
             # Now that we've (perhaps) merged authors, calculate the
             # similarity between the two records.
-            strength = book.similarity_to(r)
+            strength = edition.similarity_to(r)
             if strength > 0:
-                book.primary_identifier.equivalent_to(
-                    self.output_source, r.primary_identifier, strength)
+                edition.primary_identifier.equivalent_to(
+                    self.output_source, r.primary_identifier, strength
+                )
 
+    def process_item(self, identifier):
+        edition = self.edition(identifier)
+        if isinstance(edition, CoverageFailure):
+            return edition
+
+        # Perform a title/author lookup.
+        title, author, language = self.get_edition_info(edition)
+        xml = self.api.lookup_by(title=title, author=author)
+        try:
+            records = self.parse_edition_data(xml, edition, title, language)
+        except IOError as e:
+            return CoverageFailure(self, identifier, e)
+
+        self.merge_contributors(edition, records)
         self.log.info("Created %s records(s).", len(records))
-        return True
+        return identifier

--- a/gutenberg.py
+++ b/gutenberg.py
@@ -1,40 +1,12 @@
-import datetime
-import json
-import os
-import random
-import logging
 import re
-import requests
-import shutil
-from StringIO import StringIO
-import tarfile
-import time
-from urlparse import urljoin, urlparse
-
-from bs4 import BeautifulSoup
-
 from nose.tools import set_trace
 
 from core.coverage import CoverageProvider
-from core.model import (
-    get_one_or_create,
-    Contributor,
-    Edition,
-    DataSource,
-    Measurement,
-    Representation,
-    Resource,
-    Identifier,
-    LicensePool,
-    Subject,
-)
-
-from core.monitor import Monitor
+from core.model import DataSource
 from oclc import (
     OCLCClassifyAPI,
     OCLCXMLParser,
 )
-from core.util import LanguageCodes
 
 class OCLCClassifyCoverageProvider(CoverageProvider):
     """Does title/author lookups using OCLC Classify."""
@@ -53,7 +25,7 @@ class OCLCClassifyCoverageProvider(CoverageProvider):
         self.oclc_classify = OCLCClassifyAPI(self._db)
         input_source = DataSource.lookup(self._db, input_source_name)
         output_source = DataSource.lookup(self._db, DataSource.OCLC)
-        super(OCLCClassifyMonitor, self).__init__(
+        super(OCLCClassifyCoverageProvider, self).__init__(
             "OCLC Classify Monitor for %s" % input_source.name,
             input_source, output_source)
 

--- a/gutenberg.py
+++ b/gutenberg.py
@@ -36,8 +36,7 @@ from oclc import (
 )
 from core.util import LanguageCodes
 
-class OCLCClassifyMonitor(CoverageProvider):
-
+class OCLCClassifyCoverageProvider(CoverageProvider):
     """Does title/author lookups using OCLC Classify."""
 
     # Strips most non-alphanumerics from the title.
@@ -163,11 +162,3 @@ class OCLCClassifyMonitor(CoverageProvider):
 
         self.log.info("Created %s records(s).", len(records))
         return True
-
-class OCLCMonitorForGutenberg(OCLCClassifyMonitor):
-
-    """Track OCLC's opinions about books with the same title/author as 
-    Gutenberg works."""
-
-    def __init__(self, _db):
-        super(OCLCMonitorForGutenberg, self).__init__(_db, DataSource.GUTENBERG)

--- a/monitor.py
+++ b/monitor.py
@@ -54,10 +54,7 @@ from content_cafe import (
 from content_server import CotentServerCoverageProvider
 from overdrive import OverdriveCoverImageMirror
 from threem import ThreeMCoverImageMirror
-from gutenberg import (
-    OCLCClassifyMonitor,
-    OCLCMonitorForGutenberg,
-)
+from gutenberg import OCLCClassifyCoverageProvider
 from oclc import LinkedDataCoverageProvider
 from viaf import VIAFClient
 
@@ -274,8 +271,8 @@ class MetadataPresentationReadyMonitor(PresentationReadyMonitor):
         }
         self.image_scaler = ImageScaler(self._db, self.image_mirrors.values())
 
-        self.oclc_threem = OCLCClassifyMonitor(self._db, DataSource.THREEM)
-        self.oclc_gutenberg = OCLCMonitorForGutenberg(self._db)
+        self.oclc_threem = OCLCClassifyCoverageProvider(self._db, DataSource.THREEM)
+        self.oclc_gutenberg = OCLCClassifyCoverageProvider(self._db, DataSource.GUTENBERG)
         self.oclc_linked_data = LinkedDataCoverageProvider(self._db)
         self.viaf = VIAFClient(self._db)
 

--- a/monitor.py
+++ b/monitor.py
@@ -327,7 +327,6 @@ class MetadataPresentationReadyMonitor(PresentationReadyMonitor):
         explaining why that's not possible.
         """
         did_oclc_lookup = False
-        oclc = LinkedDataCoverageProvider(self._db, processed_uris=set())
 
         for edition in work.editions:
             accepted_data_sources = [DataSource.GUTENBERG, DataSource.THREEM]
@@ -345,13 +344,13 @@ class MetadataPresentationReadyMonitor(PresentationReadyMonitor):
             # For a given edition, it's a waste of time to process a
             # given document from OCLC Linked Data more than once.
             for o in oclc_ids:
-                oclc.ensure_coverage(o)
+                self.oclc_linked_data.ensure_coverage(o)
 
         # OCLC Linked Data on all ISBNs.
         equivalent_identifiers = primary_edition.equivalent_identifiers(
             type=[Identifier.ISBN])
         for identifier in equivalent_identifiers:
-            oclc.ensure_coverage(identifier)
+            self.oclc_linked_data.ensure_coverage(identifier)
 
         # VIAF on all contributors.
         for edition in work.editions:

--- a/monitor.py
+++ b/monitor.py
@@ -271,8 +271,7 @@ class MetadataPresentationReadyMonitor(PresentationReadyMonitor):
         }
         self.image_scaler = ImageScaler(self._db, self.image_mirrors.values())
 
-        self.oclc_threem = OCLCClassifyCoverageProvider(self._db, DataSource.THREEM)
-        self.oclc_gutenberg = OCLCClassifyCoverageProvider(self._db, DataSource.GUTENBERG)
+        self.oclc_classify = OCLCClassifyCoverageProvider(self._db)
         self.oclc_linked_data = LinkedDataCoverageProvider(self._db)
         self.viaf = VIAFClient(self._db)
 
@@ -331,18 +330,12 @@ class MetadataPresentationReadyMonitor(PresentationReadyMonitor):
         oclc = LinkedDataCoverageProvider(self._db, processed_uris=set())
 
         for edition in work.editions:
+            accepted_data_sources = [DataSource.GUTENBERG, DataSource.THREEM]
             # OCLC Lookup on all Gutenberg editions.
-            if edition.data_source.name==DataSource.GUTENBERG:
-                if not self.oclc_gutenberg.ensure_coverage(edition):
-                    # It's not a deal-breaker if we can't get OCLC
-                    # coverage on an edition.
-                    pass
-                did_oclc_lookup = True
-            elif edition.data_source.name==DataSource.THREEM:
-                if not self.oclc_threem.ensure_coverage(edition):
-                    # It's not a deal-breaker if we can't get OCLC
-                    # coverage on an edition.
-                    pass
+            if edition.data_source.name in accepted_data_sources:
+                # CoverageFailure's aren't being captured because it's not a
+                # deal-breaker if we can't get OCLC coverage on an edition.
+                self.oclc_classify.ensure_coverage(edition):
                 did_oclc_lookup = True
 
         primary_edition = work.primary_edition

--- a/oclc.py
+++ b/oclc.py
@@ -467,7 +467,6 @@ class OCLCXMLParser(XMLParser):
             raise IOError("Got single-work summary from OCLC despite requesting detail: %s" % xml)
 
         # The real action happens here.
-
         if representation_type == cls.SINGLE_WORK_DETAIL_STATUS:
             authors_tag = cls._xpath1(tree, "//oclc:authors")
             
@@ -494,21 +493,6 @@ class OCLCXMLParser(XMLParser):
                 # succeed either.
                 return representation_type, records
 
-            # data_source = DataSource.lookup(_db, DataSource.OCLC)
-            # for edition_tag in cls._xpath(work_tag, '//oclc:edition'):
-            #     edition_record, ignore = cls.extract_edition_record(
-            #         _db, edition_tag, existing_authors, **restrictions)
-            #     if not edition_record:
-            #         # This edition did not become a Edition because it
-            #         # didn't meet one of the restrictions.
-            #         continue
-            #     records.append(edition_record)
-            #     # Identify the edition with the work based on its
-            #     # primary identifier.
-            #     edition.primary_identifier.equivalent_to(
-            #         data_source, edition_record.primary_identifier)
-            #     edition_record.primary_identifier.equivalent_to(
-            #         data_source, edition.primary_identifier)
         elif representation_type == cls.MULTI_WORK_STATUS:
             # The representation lists a set of works that match the
             # search query.

--- a/scripts.py
+++ b/scripts.py
@@ -198,11 +198,6 @@ class RedoOCLC(Explain):
         identifier, ignore = Identifier.for_foreign_id(
             self._db, id_type, identifier
         )
-
-#        for edition in identifier.primarily_identifies:
-#            print "BEFORE"
-#            self.explain(self._db, edition)
-#            print "-" * 80
         self.fix_identifier(identifier)
 
     def fix_identifier(self, primary_identifier):
@@ -229,11 +224,7 @@ class RedoOCLC(Explain):
             self._db.delete(e)
         t1.commit()
 
-        #print "AFTER DELETION:"
-        #edition.work.calculate_presentation()
-        #self.explain(self._db, edition)
-
-        self.coverage.process_edition(primary_identifier)
+        self.coverage.process_item(primary_identifier)
 
         equivalent_ids = primary_identifier.equivalent_identifier_ids(
             levels=6, threshold=0)


### PR DESCRIPTION
I selfishly made some white space changes & removed some unused libraries for this PR (sorry!) so it may be easier to walk through the commits themselves to see the changes. That said, this allows the existing OCLC Coverage Providers to work with identifiers and CoverageFailures, in accordance with the new CoverageProvider details in server_core.

I wanted to add some tests, but I don't see a clear way to do that without doing a good bit of refactoring at the moment, so I'll make an issue for the refactor itself.