### PR TITLE
Combine Identifier Resolution with WorksPresentationReady Monitor

### DIFF
--- a/content_server.py
+++ b/content_server.py
@@ -31,9 +31,10 @@ class ContentServerCoverageProvider(CoverageProvider):
         self.importer = OPDSImporter(self._db, DataSource.OA_CONTENT_SERVER)
         input_identifier_types = [Identifier.GUTENBERG_ID]
         output_source = DataSource.OA_CONTENT_SERVER
-        super(ContentServerCoverageProvider, self).__init__(_db,
+        super(ContentServerCoverageProvider, self).__init__(
                 "OA Content Server Coverage Provider",
-                input_identifier_types, output_source, workset_size=10)
+                input_identifier_types, output_source, workset_size=10
+        )
 
     def process_item(self, identifier):
         response = self.content_server.lookup(identifier)

--- a/gutenberg.py
+++ b/gutenberg.py
@@ -27,15 +27,16 @@ class OCLCClassifyCoverageProvider(CoverageProvider):
     NON_TITLE_SAFE = re.compile("[^\w\-' ]", re.UNICODE)
 
     def __init__(self, _db):
-        self._db = _db
-        self.api = OCLCClassifyAPI(self._db)
         input_identifier_types = [
             Identifier.THREEM_ID, Identifier.GUTENBERG_ID, Identifier.URI
         ]
-        output_source = DataSource.lookup(self._db, DataSource.OCLC)
+        output_source = DataSource.lookup(_db, DataSource.OCLC)
         super(OCLCClassifyCoverageProvider, self).__init__(
             "OCLC Classify Coverage Provider", input_identifier_types,
             output_source)
+
+        self._db = _db
+        self.api = OCLCClassifyAPI(self._db)
 
     def oclc_safe_title(self, title):
         return self.NON_TITLE_SAFE.sub("", title)

--- a/monitor.py
+++ b/monitor.py
@@ -19,7 +19,7 @@ from fast import (
     LCSHNames,
 )
 
-from threem import ThreeMAPI
+from core.threem import ThreeMAPI
 from core.config import Configuration
 from core.overdrive import (
     OverdriveAPI,
@@ -51,11 +51,11 @@ from content_cafe import (
     ContentCafeCoverageProvider,
     ContentCafeAPI,
 )
-from content_server import CotentServerCoverageProvider
-from overdrive import OverdriveCoverImageMirror
-from threem import ThreeMCoverImageMirror
+from content_server import ContentServerCoverageProvider
 from gutenberg import OCLCClassifyCoverageProvider
 from oclc import LinkedDataCoverageProvider
+from overdrive import OverdriveCoverImageMirror
+from threem import ThreeMCoverImageMirror
 from viaf import VIAFClient
 
 class IdentifierResolutionMonitor(Monitor):

--- a/monitor.py
+++ b/monitor.py
@@ -155,6 +155,10 @@ class IdentifierResolutionMonitor(Monitor):
 
         return [overdrive, threem, content_cafe, content_server, oclc_classify]
 
+    def eligible_providers_for(self, identifier):
+        return [provider for provider in self.providers if identifier.type in
+                provider.input_identifier_types]
+
     def run_once(self, start, cutoff):
         self.create_missing_unresolved_identifiers()
         unresolved_identifiers = self.fetch_unresolved_identifiers()
@@ -165,8 +169,7 @@ class IdentifierResolutionMonitor(Monitor):
         for unresolved_identifier in unresolved_identifiers:
             # Evaluate which providers this Identifier needs coverage from.
             identifier = unresolved_identifier.identifier
-            eligible_providers = [provider for provider in self.providers
-                    if identifier.type in provider.input_identifier_types]
+            eligible_providers = self.eligible_providers_for(identifer)
             self.log.info("Ensuring coverage for %r", identifier)
             self._log_providers(identifier, eligible_providers)
 
@@ -254,6 +257,11 @@ class IdentifierResolutionMonitor(Monitor):
         return not not unresolved_equivalents
 
     def resolve_equivalent_oclc_identifiers(self, identifier):
+        """Ensures OCLC coverage for an identifier.
+
+        This has to be called after the OCLCClassify coverage is run to confirm
+        that equivalent OCLC identifiers are available.
+        """
         primary_edition = identifier.equivalencies
         oclc_ids = primary_edition.equivalent_identifiers(
             type=[Identifier.OCLC_WORK, Identifier.OCLC_NUMBER, Identifier.ISBN]

--- a/monitor.py
+++ b/monitor.py
@@ -204,12 +204,6 @@ class IdentifierResolutionMonitor(Monitor):
                 unresolved_identifier.most_recent_attempt = now
                 if not unresolved_identifier.first_attempt:
                     unresolved_identifier.first_attempt = now
-            elif has_unresolved_equivalents(identifier):
-                # This identifier isn't ready to have its work processed because
-                # it has other equivalent identifiers that haven't been resolved
-                # yet. Once they've all been resolved, the work'll be processed
-                # and set to presentation-ready.
-                pass
             else:
                 try:
                     self.resolve_equivalent_oclc_identifiers(identifier)
@@ -245,16 +239,6 @@ class IdentifierResolutionMonitor(Monitor):
         else:
             exception = "Work could not be calculated for %r" % unresolved_identifier.identifier
             process_failure(unresolved_identifier, exception)
-
-    def has_unresolved_equivalents(self, identifier):
-        """Determines whether an identifier has equivalent identifiers that are
-        unresolved. Returns a boolean value."""
-        equivalent_identifiers = [eq.output for eq in identifier.equivalencies]
-        equivalent_identifiers += [eq.input for eq in 
-                identifier.inbound_equivalencies]
-        unresolved_equivalents = [eq_id.unresolved_identifier for eq_id in
-                equivalent_identifiers if eq_id.unresolved_identifier]
-        return not not unresolved_equivalents
 
     def resolve_equivalent_oclc_identifiers(self, identifier):
         """Ensures OCLC coverage for an identifier.

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -2,14 +2,53 @@ from nose.tools import set_trace, eq_
 from . import DatabaseTest
 from ..monitor import IdentifierResolutionMonitor
 from ..core.model import (
-    Equivalency,
     DataSource,
+    Identifier,
 )
+
+class DummyIdentifierResolutionMonitor(IdentifierResolutionMonitor):
+    """An IdentifierRestolutionMonitor for testing"""
+
+    def __init__(self):
+        self.service_name = "Dummy Identifier Resolution Monitor"
+
+    @property
+    def providers(self):
+        provider_types = [
+            Identifier.ISBN, Identifier.OVERDRIVE_ID, Identifier.THREEM_ID,
+            [Identifier.THREEM_ID, Identifier.ISBN],
+            [Identifier.GUTENBERG_ID, Identifier.OCLC_WORK]
+        ]
+        return [DummyCoverageProvider(types) for types in provider_types]
+
+
+class DummyCoverageProvider(object):
+    def __init__(self, identifier_types):
+        if not isinstance(identifier_types, list):
+            identifier_types = [identifier_types]
+        self.input_identifier_types = identifier_types
+
 
 class TestIdentifierResolutionMonitor(DatabaseTest):
     def setup(self):
         super(TestIdentifierResolutionMonitor, self).setup()
-        self.monitor = IdentifierResolutionMonitor(self._db)
+        self.monitor = DummyIdentifierResolutionMonitor()
+
+    def test_eligible_providers_for(self):
+        gutenberg = self._identifier()
+        threem = self._identifier(identifier_type=Identifier.THREEM_ID)
+        oclc = self._identifier(identifier_type=Identifier.OCLC_WORK)
+        isbn = self._identifier(identifier_type=Identifier.ISBN)
+
+        gutenberg_providers = self.monitor.eligible_providers_for(gutenberg)
+        threem_providers = self.monitor.eligible_providers_for(threem)
+        oclc_providers = self.monitor.eligible_providers_for(oclc)
+        isbn_providers = self.monitor.eligible_providers_for(isbn)
+
+        eq_(1, len(gutenberg_providers))
+        eq_(2, len(threem_providers))
+        eq_(1, len(oclc_providers))
+        eq_(2, len(isbn_providers))
 
     def test_has_unresolved_equivalents(self):
         identifier = self._identifier()
@@ -24,7 +63,7 @@ class TestIdentifierResolutionMonitor(DatabaseTest):
         eq_(True, self.monitor.has_unresolved_equivalents(identifier))
 
     def test_process_failure(self):
-        exception = "Hello from the other siiiiide"
+        exception = u"Hello from the other siiiiide"
         unresolved, ignore = self._unresolved_identifier(self._identifier())
         processed_unresolved = self.monitor.process_failure(unresolved, exception)
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,10 +1,7 @@
 from nose.tools import set_trace, eq_
 from . import DatabaseTest
 from ..monitor import IdentifierResolutionMonitor
-from ..core.model import (
-    DataSource,
-    Identifier,
-)
+from ..core.model import Identifier
 
 class DummyIdentifierResolutionMonitor(IdentifierResolutionMonitor):
     """An IdentifierRestolutionMonitor for testing"""
@@ -49,18 +46,6 @@ class TestIdentifierResolutionMonitor(DatabaseTest):
         eq_(2, len(threem_providers))
         eq_(1, len(oclc_providers))
         eq_(2, len(isbn_providers))
-
-    def test_has_unresolved_equivalents(self):
-        identifier = self._identifier()
-        eq_(False, self.monitor.has_unresolved_equivalents(identifier))
-
-        eq_identifier = self._identifier()
-        unresolved = self._unresolved_identifier(eq_identifier)
-        identifier.equivalent_to(
-            DataSource.lookup(self._db, DataSource.GUTENBERG), eq_identifier, 1
-        )
-        self._db.commit()
-        eq_(True, self.monitor.has_unresolved_equivalents(identifier))
 
     def test_process_failure(self):
         exception = u"Hello from the other siiiiide"

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,7 +1,7 @@
 from nose.tools import set_trace, eq_
 from . import DatabaseTest
 from ..monitor import IdentifierResolutionMonitor
-from core.model import (
+from ..core.model import (
     Equivalency,
     DataSource,
 )

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,32 @@
+from nose.tools import set_trace, eq_
+from . import DatabaseTest
+from ..monitor import IdentifierResolutionMonitor
+from core.model import (
+    Equivalency,
+    DataSource,
+)
+
+class TestIdentifierResolutionMonitor(DatabaseTest):
+    def setup(self):
+        super(TestIdentifierResolutionMonitor, self).setup()
+        self.monitor = IdentifierResolutionMonitor(self._db)
+
+    def test_has_unresolved_equivalents(self):
+        identifier = self._identifier()
+        eq_(False, self.monitor.has_unresolved_equivalents(identifier))
+
+        eq_identifier = self._identifier()
+        unresolved = self._unresolved_identifier(eq_identifier)
+        identifier.equivalent_to(
+            DataSource.lookup(self._db, DataSource.GUTENBERG), eq_identifier, 1
+        )
+        self._db.commit()
+        eq_(True, self.monitor.has_unresolved_equivalents(identifier))
+
+    def test_process_failure(self):
+        exception = "Hello from the other siiiiide"
+        unresolved, ignore = self._unresolved_identifier(self._identifier())
+        processed_unresolved = self.monitor.process_failure(unresolved, exception)
+
+        eq_(unresolved, processed_unresolved)
+        eq_(True, unresolved.exception.endswith("siiiiide"))


### PR DESCRIPTION
Brings the work of resolving identifiers against existing coverage providers together with setting works as presentation ready. (In this context, presentation-ready means the Metadata Wrangler looked everywhere for information.)

Fixes #24.