### PR TITLE
Add author to oclc data

### DIFF
--- a/bin/redo_oclc_for_threem
+++ b/bin/redo_oclc_for_threem
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+"""Lookup OCLC data -- now including authors -- for ThreeM works that are
+missing authors"""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.scripts import RefreshMaterializedViewsScript
+from scripts import RedoOCLCForThreeMScript
+
+RedoOCLCForThreeMScript.run()
+RefreshMaterializedViewsScript.run()

--- a/oclc.py
+++ b/oclc.py
@@ -99,6 +99,8 @@ class OCLCLinkedData(object):
     URI_WITH_ISBN = re.compile('^http://[^/]*worldcat.org/.*isbn/([0-9X]+)$')
     URI_WITH_OCLC_WORK_ID = re.compile('^http://[^/]*worldcat.org/.*work/id/([0-9]+)$')
 
+    VIAF_ID = re.compile("^http://viaf.org/viaf/([0-9]+)/$")
+
     CAN_HANDLE = set([Identifier.OCLC_WORK, Identifier.OCLC_NUMBER,
                       Identifier.ISBN])
 
@@ -544,7 +546,7 @@ class OCLCLinkedData(object):
 
         for n in publisher_names:
             if (n in self.PUBLISHER_BLACKLIST
-                or 'Audio' in n or 'Video' in n or 'n Tape' in n
+                or 'Audio' in n or 'Video' in n or 'Tape' in n
                 or 'Comic' in n or 'Music' in n):
                 # This book is from a publisher that will probably not
                 # give us metadata we can use.
@@ -559,7 +561,7 @@ class OCLCLinkedData(object):
 
         creator_viafs = []
         for uri in creator_uris:
-            if not uri.startswith("http://viaf.org"):
+            if not self.VIAF_ID.search(uri):
                 continue
             viaf = uri[uri.rindex('/')+1:]
             creator_viafs.append(viaf)
@@ -1351,9 +1353,8 @@ class LinkedDataCoverageProvider(CoverageProvider):
 
         metadata = Metadata(self.output_source)
         # Return contributor information.
-        VIAF_ID = re.compile("^http://viaf.org/viaf/([0-9]+)/$")
         for viaf in edition['creator_viafs']:
-            viaf = VIAF_ID.search(viaf).groups()[0]
+            viaf = self.api.VIAF_ID.search(viaf).groups()[0]
             contributor = ContributorData(viaf=viaf)
             metadata.contributors.append(contributor)
 

--- a/oclc.py
+++ b/oclc.py
@@ -1351,7 +1351,9 @@ class LinkedDataCoverageProvider(CoverageProvider):
 
         metadata = Metadata(self.output_source)
         # Return contributor information.
+        VIAF_ID = re.compile("^http://viaf.org/viaf/([0-9]+)/$")
         for viaf in edition['creator_viafs']:
+            viaf = VIAF_ID.search(viaf).groups()[0]
             contributor = ContributorData(viaf=viaf)
             metadata.contributors.append(contributor)
 

--- a/scripts.py
+++ b/scripts.py
@@ -238,3 +238,21 @@ class RedoOCLC(Explain):
                 edition.work.calculate_presentation()
             self.explain(self._db, edition)
         print "I WOULD NOW EXPECT EVERYTHING TO BE FINE."
+
+class RedoOCLCforThreeM(Script):
+
+    def __init__(self):
+        self.input_data_source = DataSource.lookup(self._db, )
+        self.coverage = LinkedDataCoverageProvider(self._db)
+
+    def run(self):
+        """"""
+        # destroy linked data coverage record
+        # run oclc classify if there's no isbn equivalence
+        # ensure coverage by linked data coverage provider
+        pass
+
+    def fetch_threem_works_without_authors(self):
+        """Pulls out ThreeM Editions that don't have authors, along with their
+        OCLC Linked Data coverage records & ISBN identifiers"""
+        pass

--- a/tests/test_oclc.py
+++ b/tests/test_oclc.py
@@ -388,4 +388,7 @@ class TestLinkedDataCoverageProvider(DatabaseTest):
             identifier, oclc_record
         )
 
-        eq_(True, isinstance(oclc_edition_data[0], Metadata))
+        metadata_obj = oclc_edition_data[0]
+        eq_(True, isinstance(metadata_obj, Metadata))
+        eq_(1, len(metadata_obj.contributors))
+        eq_("71398958", metadata_obj.contributors[0].viaf)

--- a/tests/test_oclc.py
+++ b/tests/test_oclc.py
@@ -12,9 +12,12 @@ from ..core.model import (
     Edition,
     )
 
+from ..core.metadata_layer import Metadata
+
 from ..oclc import (
     OCLCXMLParser,
     OCLCLinkedData,
+    LinkedDataCoverageProvider,
 )
 
 from . import (
@@ -360,3 +363,30 @@ class TestOCLCLinkedData(TestParser):
                  "http://viaf.org/viaf/221233754", 
                  "http://viaf.org/viaf/305306689"]),
             set(uris))
+
+
+class TestLinkedDataCoverageProvider(DatabaseTest):
+    def test_process_oclc_edition(self):
+        # it returns a metadata object
+        oclc_record = dict(
+            oclc_id_type="OCLC Work ID", oclc_id="1401160532",
+            titles="Book Title",
+            descriptions=["Hi there! I am a book. I am \
+            made of paper and have many beneficial pages."],
+            subjects={},
+            creator_viafs=["http://viaf.org/viaf/71398958/"],
+            publishers=[],
+            publication_dates=[],
+            types=[],
+            isbns=[],
+        )
+
+        identifier = self._identifier(identifier_type = oclc_record['oclc_id_type'])
+        identifier.identifier = oclc_record['oclc_id']
+
+        oclc_edition_data = LinkedDataCoverageProvider(self._db).process_oclc_edition(
+            identifier, oclc_record
+        )
+
+        eq_(True, isinstance(oclc_edition_data[0], Metadata))
+        pass

--- a/tests/test_oclc.py
+++ b/tests/test_oclc.py
@@ -389,4 +389,3 @@ class TestLinkedDataCoverageProvider(DatabaseTest):
         )
 
         eq_(True, isinstance(oclc_edition_data[0], Metadata))
-        pass

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,92 @@
+from nose.tools import set_trace, eq_
+from . import DatabaseTest
+from ..scripts import RedoOCLCForThreeMScript
+from ..core.model import (
+    Identifier,
+    DataSource,
+    CoverageRecord,
+)
+
+class DummyCoverageProvider(object):
+    hit_count = 0
+
+    def ensure_coverage(self, identifier):
+        self.hit_count += 1
+
+class TestRedoOCLCForThreeM(DatabaseTest):
+
+    def setup(self):
+        super(TestRedoOCLCForThreeM, self).setup()
+        self.script = RedoOCLCForThreeMScript(self._db)
+        
+        self.edition1, lp = self._edition(
+            data_source_name = DataSource.THREEM,
+            identifier_type = Identifier.THREEM_ID,
+            with_license_pool = True,
+            title = "Metropolis"
+        )
+
+        self.edition2, lp = self._edition(
+            data_source_name = DataSource.THREEM,
+            identifier_type = Identifier.THREEM_ID,
+            with_license_pool = True,
+            title = "The ArchAndroid"
+        )
+        # Give edition2 a coverage record.
+        self._coverage_record(self.edition2, self.script.input_data_source)
+
+        # Create a control case.
+        self.edition3, lp = self._edition(
+            data_source_name = DataSource.THREEM,
+            identifier_type = Identifier.THREEM_ID,
+            with_license_pool = True,
+            title = "The Electric Lady"
+        )
+        self._db.commit()
+
+        # Remove contributors for the first two editions.
+        contributions = self.edition1.contributions + self.edition2.contributions
+        contributors = self.edition1.contributors + self.edition2.contributors
+        for c in contributions + contributions:
+            self._db.delete(c)
+        self._db.commit()
+
+    def test_fetch_authorless_threem_identifiers(self):
+        identifiers = self.script.fetch_authorless_threem_identifiers()
+
+        # Both the editions with and without coverage records are selected...
+        eq_(2, len(identifiers))
+        # ...while the edition with contributors is not.
+        assert self.edition3.primary_identifier not in identifiers
+
+    def test_delete_coverage_records(self):
+        coverage_records_before = self._db.query(CoverageRecord).all()
+        eq_(1, len(coverage_records_before))
+        eq_(self.edition2.primary_identifier, coverage_records_before[0].identifier)
+
+        identifiers = [self.edition1.primary_identifier, self.edition2.primary_identifier]
+        self.script.delete_coverage_records(identifiers)
+        coverage_records_after = self._db.query(CoverageRecord).all()
+        eq_(0, len(coverage_records_after))
+
+    def test_ensure_isbn_identifier(self):
+
+        self.script.oclc_classify = DummyCoverageProvider()
+        eq_(0, self.script.oclc_classify.hit_count)
+
+        # When there are no equivalent identifiers, both identifiers go to the
+        # OCLCClassify coverage provider.
+        identifiers = [self.edition1.primary_identifier, self.edition2.primary_identifier]
+        self.script.ensure_isbn_identifier(identifiers)
+        eq_(2, self.script.oclc_classify.hit_count)
+
+        # If an edition already has an ISBN identifier it doesn't go to the
+        # coverage provider.
+        self.script.oclc_classify.hit_count = 0
+        self.edition1.primary_identifier.equivalent_to(
+            DataSource.lookup(self._db, DataSource.GUTENBERG),
+            self._identifier(identifier_type = Identifier.ISBN), 1
+        )
+        self._db.commit()
+        self.script.ensure_isbn_identifier(identifiers)
+        eq_(1, self.script.oclc_classify.hit_count)


### PR DESCRIPTION
I moved a bunch of methods previously in the coverage provider up into the API, and then I made sure that the creator viafs are being passed back to the Coverage Provider.

There's also a schweet script to pull the ThreeM books that are running about without authors and give them some contributors. Probably.

Paves the way for #29. Fixes NYPL-Simplified/server_core#17.

@leonardr: Sorry this PR is so big! I'll work on keeping them smaller & easier to review.