### PR TITLE
Make the identifier resolution process complete for ISBNs

### DIFF
--- a/bin/identifiers_resolve
+++ b/bin/identifiers_resolve
@@ -5,7 +5,5 @@ import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
-from core.scripts import RunMonitorScript
-
-from monitor import IdentifierResolutionMonitor
-RunMonitorScript(IdentifierResolutionMonitor).run()
+from scripts import RunIdentifierResolutionMonitor
+RunIdentifierResolutionMonitor().run()

--- a/monitor.py
+++ b/monitor.py
@@ -40,6 +40,7 @@ from core.model import (
     DataSource,
     Edition,
     Equivalency,
+    Hyperlink,
     Identifier,
     LicensePool,
     Subject,
@@ -150,7 +151,14 @@ class IdentifierResolutionMonitor(CoreIdentifierResolutionMonitor):
     def finalize(self, unresolved_identifier):
         identifier = unresolved_identifier.identifier
         self.resolve_equivalent_oclc_identifiers(identifier)
-        self.process_work(unresolved_identifier)
+        if unresolved_identifier.identifier.type==Identifier.ISBN:
+            # Currently we don't try to create Works for ISBNs,
+            # we just make sure all the Resources associated with the
+            # ISBN are properly handled. At this point, that has
+            # completed successfully, so do nothing.
+            pass
+        else:
+            self.process_work(unresolved_identifier)
 
     def process_work(self, unresolved_identifier):
         """Fill in VIAF data and cover images where possible before setting
@@ -160,6 +168,7 @@ class IdentifierResolutionMonitor(CoreIdentifierResolutionMonitor):
         license_pool = unresolved_identifier.identifier.licensed_through
         if license_pool:
             work, created = license_pool.calculate_work(even_if_no_author=True)
+        set_trace()
         if work:
             self.resolve_viaf(work)
             self.resolve_cover_image(work)

--- a/monitor.py
+++ b/monitor.py
@@ -168,7 +168,6 @@ class IdentifierResolutionMonitor(CoreIdentifierResolutionMonitor):
         license_pool = unresolved_identifier.identifier.licensed_through
         if license_pool:
             work, created = license_pool.calculate_work(even_if_no_author=True)
-        set_trace()
         if work:
             self.resolve_viaf(work)
             self.resolve_cover_image(work)


### PR DESCRIPTION
This branch makes finalize() realize that you don't need to create a Work for an ISBN for the ISBN to be 'finalized' in a metadata wrangler sense.

I also change the identifiers_resolve script so that you can pass in some identifiers that need to be resolved (or made unresolved and then resolved). This makes problems easier to troubleshoot.