### PR TITLE
Use metadata layer for oclcld

### DIFF
--- a/oclc.py
+++ b/oclc.py
@@ -172,7 +172,6 @@ class OCLCLinkedData(object):
     ])
 
     FILTER_TAGS = POINTLESS_TAGS.union(TAGS_FOR_UNUSABLE_RECORDS)
-    UNUSABLE_RECORD = object()
 
     def __init__(self, _db):
         self._db = _db
@@ -564,17 +563,15 @@ class OCLCLinkedData(object):
                         ))
 
         # Consolidate subjects and apply a blacklist.
-        tags = set()
-        for tag in subjects.get(Subject.TAG, []):
-            fixed = self._fix_tag(tag)
-            if fixed == self.UNUSABLE_RECORD:
-                return None
-            if fixed:
-                tags.add(fixed)
-        for tag in tags:
-            metadata.subjects.append(SubjectData(
-                type=Subject.TAG, identifier=tag
-            ))
+        fixed = [self._fix_tag(tag) for tag in subjects.get(Subject.TAG, [])]
+        fixed_tags = [tag for tag in fixed if not None ]
+        subjects[Subject.TAG] = fixed_tags
+
+        for subject_type, subject_identifiers in subjects.items():
+            for subject_identifier in subject_identifiers:
+                metadata.subjects.append(SubjectData(
+                    type=subject_type, identifier=subject_identifier
+                ))
 
         if (not metadata.links and not metadata.identifiers and
             not metadata.subjects):

--- a/oclc.py
+++ b/oclc.py
@@ -548,7 +548,6 @@ class OCLCLinkedData(object):
             metadata.publisher = publisher_names[0]
 
         # Grab all the ISBNs.
-        isbns = set()
         example_graphs = self.internal_lookup(subgraph, example_uris)
         for example in example_graphs:
             for isbn_name in 'schema:isbn', 'isbn':
@@ -573,18 +572,18 @@ class OCLCLinkedData(object):
                     type=subject_type, identifier=subject_identifier
                 ))
 
-        if (not metadata.links and not metadata.identifiers and
-            not metadata.subjects):
-            # Something interesting has to come out of this
-            # work--something we couldn't get from another source--or
-            # there's no point.
-            return None
-
         for uri in creator_uris:
             viaf_uri = self.VIAF_ID.search(uri)
             if viaf_uri:
                 viaf = viaf_uri.groups()[0]
                 metadata.contributors.append(ContributorData(viaf=viaf))
+
+        if (not metadata.links and not metadata.identifiers and
+            not metadata.subjects and not metadata.contributors):
+            # Something interesting has to come out of this
+            # work--something we couldn't get from another source--or
+            # there's no point.
+            return None
 
         return metadata
 

--- a/oclc.py
+++ b/oclc.py
@@ -102,7 +102,7 @@ class OCLCLinkedData(object):
     URI_WITH_ISBN = re.compile('^http://[^/]*worldcat.org/.*isbn/([0-9X]+)$')
     URI_WITH_OCLC_WORK_ID = re.compile('^http://[^/]*worldcat.org/.*work/id/([0-9]+)$')
 
-    VIAF_ID = re.compile("^http://viaf.org/viaf/([0-9]+)/$")
+    VIAF_ID = re.compile("^http://viaf.org/viaf/([0-9]+)/?$")
 
     CAN_HANDLE = set([Identifier.OCLC_WORK, Identifier.OCLC_NUMBER,
                       Identifier.ISBN])

--- a/oclc.py
+++ b/oclc.py
@@ -379,7 +379,6 @@ class OCLCLinkedData(object):
             # Kind of weird, but okay.
             id_type = Identifier.OCLC_WORK
         else:
-            self.log.warn("EXPECTED OCLC ID, got %s" % id_type)
             return no_value
 
         for k, repository in (
@@ -486,15 +485,19 @@ class OCLCLinkedData(object):
         for data in self.graphs_for(identifier):
             subgraph = self.graph(data)
             for book in self.books(subgraph):
-                info = self.info_for_book_graph(subgraph, book)
+                info = self.book_info_to_metadata(subgraph, book)
                 if info:
-                    yield self.book_info_to_metadata(info)
+                    yield info
 
-    def info_for_book_graph(self, subgraph, book_info):
-        """Filters raw book information to exclude irrelevant or unhelpful data
+    def book_info_to_metadata(self, subgraph, book_info):
+        """Filters raw book information to exclude irrelevant or unhelpful data.
 
-        :returns: None if information is unhelpful; dict of book info otherwise.
+        :returns: None if information is unhelpful; metadata object otherwise.
         """
+        self.log.info(
+            "Processing edition %s: %r", book_info.get('oclc_id'),
+            book_info.get('titles')
+        )
         if not self._has_relevant_types(book_info):
             # This book is not available in any format we're
             # interested in from a metadata perspective.
@@ -506,11 +509,46 @@ class OCLCLinkedData(object):
          descriptions,
          subjects,
          creator_uris,
-         publisher_uris,
+         publisher_names,
          publication_dates,
          example_uris) = self.extract_useful_data(subgraph, book_info)
 
-        isbns = set([])
+        if not oclc_id_type or not oclc_id:
+            return None
+
+        metadata = Metadata(self.source)
+        metadata.primary_identifier, new = Identifier.for_foreign_id(
+            self._db, oclc_id_type, oclc_id
+        )
+        metadata.title = titles[0]
+        for d in publication_dates:
+            try:
+                metadata.published = datetime.datetime.strptime(d[:4], "%Y")
+            except Exception, e:
+                pass
+
+        for description in descriptions:
+            # Create a description resource for every description.  When there's
+            # more than one description for a given edition, only one of them is
+            # actually a description. The others are tables of contents or some
+            # other stuff we don't need. Unfortunately I can't think of an
+            # automatic way to tell which is the good description.
+            metadata.links.append(LinkData(
+                Hyperlink.DESCRIPTION, media_type=Representation.TEXT_PLAIN,
+                content=description,
+            ))
+
+        if 'Project Gutenberg' in publisher_names and not metadata.links:
+            # Project Gutenberg texts don't have ISBNs, so if there's an
+            # ISBN on there, it's probably wrong. Unless someone stuck a
+            # description on there, there's no point in discussing
+            # OCLC+LD's view of a Project Gutenberg work.
+            return None
+        if publisher_names:
+            metadata.publisher = publisher_names[0]
+
+        # Grab all the ISBNs.
+        isbns = set()
         example_graphs = self.internal_lookup(subgraph, example_uris)
         for example in example_graphs:
             for isbn_name in 'schema:isbn', 'isbn':
@@ -520,7 +558,9 @@ class OCLCLinkedData(object):
                     elif len(isbn) != 13:
                         continue
                     if isbn:
-                        isbns.add(isbn)
+                        metadata.identifiers.append(IdentifierData(
+                            type = Identifier.ISBN, identifier = isbn
+                        ))
 
         # Consolidate subjects and apply a blacklist.
         tags = set()
@@ -528,111 +568,26 @@ class OCLCLinkedData(object):
             fixed = self._fix_tag(tag)
             if fixed == self.UNUSABLE_RECORD:
                 return None
-            elif fixed:
+            if fixed:
                 tags.add(fixed)
-        if tags:
-            subjects[Subject.TAG] = tags
-        elif Subject.TAG in subjects:
-            del subjects[Subject.TAG]
+        for tag in tags:
+            metadata.subjects.append(SubjectData(
+                type=Subject.TAG, identifier=tag
+            ))
 
-        # Something interesting has to come out of this
-        # work--something we couldn't get from another source--or
-        # there's no point.
-        if not isbns and not descriptions and not subjects:
+        if (not metadata.links and not metadata.identifiers and
+            not metadata.subjects):
+            # Something interesting has to come out of this
+            # work--something we couldn't get from another source--or
+            # there's no point.
             return None
 
-        publishers = self.internal_lookup(
-            subgraph, publisher_uris)
-        publisher_names = [
-            i['schema:name'] for i in publishers
-            if 'schema:name' in i]
-        publisher_names = list(ldq.values(
-            ldq.restrict_to_language(publisher_names, 'en')))
-
-        for n in publisher_names:
-            if (n in self.PUBLISHER_BLACKLIST
-                or 'Audio' in n or 'Video' in n or 'Tape' in n
-                or 'Comic' in n or 'Music' in n):
-                # This book is from a publisher that will probably not
-                # give us metadata we can use.
-                return None
-
-        # Project Gutenberg texts don't have ISBNs, so if there's an
-        # ISBN on there, it's probably wrong. Unless someone stuck a
-        # description on there, there's no point in discussing
-        # OCLC+LD's view of a Project Gutenberg work.
-        if 'Project Gutenberg' in publisher_names and not descriptions:
-            return None
-
-        creator_viafs = []
         for uri in creator_uris:
-            viaf_uri_match = self.VIAF_ID.search(uri)
-            if viaf_uri_match:
-                viaf = viaf_uri_match.groups()[0]
-                creator_viafs.append(viaf)
+            viaf_uri = self.VIAF_ID.search(uri)
+            if viaf_uri:
+                viaf = viaf_uri.groups()[0]
+                metadata.contributors.append(ContributorData(viaf=viaf))
 
-        r = dict(
-            oclc_id_type=oclc_id_type,
-            oclc_id=oclc_id,
-            titles=titles,
-            descriptions=descriptions,
-            subjects=subjects,
-            creator_viafs=creator_viafs,
-            publishers=publisher_names,
-            publication_dates=publication_dates,
-            isbns=isbns,
-        )
-        return r
-
-    def book_info_to_metadata(self, book_info):
-        """Transforms dictionary-style book info into a Metadata object"""
-        self.log.info(
-            "Processing edition %s: %r", book_info.get('oclc_id'),
-            book_info.get('titles')
-        )
-        metadata = Metadata(self.source)
-        metadata.primary_identifier, new = Identifier.for_foreign_id(
-            self._db, book_info['oclc_id_type'], book_info['oclc_id']
-        )
-
-        if book_info['titles']:
-            metadata.title = book_info['titles'][0]
-        if book_info['publishers']:
-            metadata.publisher = book_info['publishers'][0]
-        for d in book_info['publication_dates']:
-            # Try to find a publication year.
-            try:
-                metadata.published = datetime.datetime.strptime(
-                    d[:4], "%Y")
-            except Exception, e:
-                pass
-        for subject_type, subject_ids in book_info['subjects'].items():
-            for subject_id in subject_ids:
-                subject = SubjectData(type=subject_type, identifier=subject_id)
-                metadata.subjects.append(subject)
-        for isbn in book_info['isbns']:
-            # Create new ISBNs associated with the OCLC
-            # number. This will help us get metadata from other
-            # sources that use ISBN as input.
-            isbn_identifier = IdentifierData(type = Identifier.ISBN, identifier = isbn)
-            metadata.identifiers.append(isbn_identifier)
-        for viaf in book_info['creator_viafs']:
-            # Return any contributor VIAFS.
-            contributor = ContributorData(viaf=viaf)
-            metadata.contributors.append(contributor)
-        for description in book_info['descriptions']:
-            # Create a description resource for every description.  When
-            # there's more than one description for a given edition, only
-            # one of them is actually a description. The others are tables
-            # of contents or some other stuff we don't need. Unfortunately
-            # I can't think of an automatic way to tell which is the good
-            # description.
-            description = LinkData(
-                Hyperlink.DESCRIPTION,
-                media_type=Representation.TEXT_PLAIN,
-                content=description,
-            )
-            metadata.links.append(description)
         return metadata
 
     def _has_relevant_types(self, book_info):

--- a/oclc.py
+++ b/oclc.py
@@ -369,6 +369,7 @@ class OCLCLinkedData(object):
 
         id_uri = book['@id']
         m = cls.URL_ID_RE.match(id_uri)
+
         if not m:
             return no_value
 

--- a/tests/files/oclc/galapagos.jsonld
+++ b/tests/files/oclc/galapagos.jsonld
@@ -1,0 +1,222 @@
+{
+  "@graph" : [ {
+    "@id" : "http://dewey.info/class/813.54/e19/",
+    "@type" : "schema:Intangible"
+  }, {
+    "@id" : "http://experiment.worldcat.org/entity/work/data/1859790419#Agent/delacorte_press_seymour_lawrence",
+    "@type" : "bgn:Agent",
+    "name" : "Delacorte Press/Seymour Lawrence"
+  }, {
+    "@id" : "http://experiment.worldcat.org/entity/work/data/1859790419#Place/galapagos_islands",
+    "@type" : "schema:Place",
+    "name" : "Galapagos Islands"
+  }, {
+    "@id" : "http://experiment.worldcat.org/entity/work/data/1859790419#Place/new_york_n_y",
+    "@type" : "schema:Place",
+    "name" : "New York, N.Y."
+  }, {
+    "@id" : "http://experiment.worldcat.org/entity/work/data/1859790419#Topic/ghosts",
+    "@type" : "schema:Intangible",
+    "name" : {
+      "@language" : "en",
+      "@value" : "Ghosts"
+    },
+    "seeAlso" : "http://id.loc.gov/authorities/subjects/sj96005617"
+  }, {
+    "@id" : "http://experiment.worldcat.org/entity/work/data/1859790419#Topic/islands",
+    "@type" : "schema:Intangible",
+    "name" : {
+      "@language" : "en",
+      "@value" : "Islands"
+    },
+    "seeAlso" : "http://id.loc.gov/authorities/subjects/sh2008104288"
+  }, {
+    "@id" : "http://experiment.worldcat.org/entity/work/data/1859790419#Topic/satirical_fiction",
+    "@type" : "schema:Intangible",
+    "name" : {
+      "@language" : "en",
+      "@value" : "satirical fiction"
+    }
+  }, {
+    "@id" : "http://id.loc.gov/authorities/subjects/sh85062975",
+    "@type" : "schema:Intangible",
+    "name" : {
+      "@language" : "en",
+      "@value" : "Humorous stories"
+    }
+  }, {
+    "@id" : "http://id.loc.gov/authorities/subjects/sh85118637",
+    "@type" : "schema:Intangible",
+    "name" : {
+      "@language" : "en",
+      "@value" : "Science fiction, American"
+    }
+  }, {
+    "@id" : "http://id.loc.gov/vocabulary/countries/nyu",
+    "@type" : "schema:Place",
+    "identifier" : "nyu"
+  }, {
+    "@id" : "http://id.worldcat.org/fast/1219610",
+    "@type" : "schema:Place",
+    "name" : "Galapagos Islands."
+  }, {
+    "@id" : "http://viaf.org/viaf/71398958",
+    "@type" : "schema:Person",
+    "familyName" : "Vonnegut",
+    "givenName" : "Kurt",
+    "name" : "Kurt Vonnegut"
+  }, {
+    "@id" : "http://worldcat.org/isbn/9780385294164",
+    "@type" : "schema:ProductModel",
+    "isbn" : [ "9780385294164", "0385294166" ]
+  }, {
+    "@id" : "http://worldcat.org/isbn/9780385294201",
+    "@type" : "schema:ProductModel",
+    "isbn" : [ "9780385294201", "0385294204" ]
+  }, {
+    "@id" : "http://www.worldcat.org/oclc/11866009",
+    "@type" : [ "schema:CreativeWork", "schema:Book" ],
+    "oclcnum" : "11866009",
+    "placeOfPublication" : [ "http://experiment.worldcat.org/entity/work/data/1859790419#Place/new_york_n_y", "http://id.loc.gov/vocabulary/countries/nyu" ],
+    "about" : [ "http://experiment.worldcat.org/entity/work/data/1859790419#Topic/islands", "http://dewey.info/class/813.54/e19/", "http://id.worldcat.org/fast/1219610", "http://id.loc.gov/authorities/subjects/sh85062975", "http://experiment.worldcat.org/entity/work/data/1859790419#Topic/satirical_fiction", "http://experiment.worldcat.org/entity/work/data/1859790419#Place/galapagos_islands", "http://id.loc.gov/authorities/subjects/sh85118637", "http://experiment.worldcat.org/entity/work/data/1859790419#Topic/ghosts" ],
+    "audience" : "http://www.worldcat.org/title/-/oclc/11866009#Audience",
+    "bookEdition" : "1st trade ed.",
+    "bookFormat" : "bgn:PrintBook",
+    "copyrightYear" : "1985",
+    "creator" : "http://viaf.org/viaf/71398958",
+    "datePublished" : "1985",
+    "description" : {
+      "@language" : "en",
+      "@value" : "Observed by a ghost of the Vietnam War for one million years, the descendants of survivors of a cruise to the Galapagos Archipielago prove Darwin's Theory of Evolution. The ghost of a shipbuilder tells the story of an ill-fated cruise to the Galapagos Islands."
+    },
+    "exampleOfWork" : "http://worldcat.org/entity/work/id/1859790419",
+    "genre" : {
+      "@language" : "en",
+      "@value" : "Fiction"
+    },
+    "inLanguage" : "en",
+    "isSimilarTo" : "http://www.worldcat.org/oclc/559361680",
+    "name" : {
+      "@language" : "en",
+      "@value" : "Galápagos : a novel"
+    },
+    "productID" : "11866009",
+    "publication" : "http://www.worldcat.org/title/-/oclc/11866009#PublicationEvent/new_york_n_y_delacorte_press_seymour_lawrence_1985",
+    "publisher" : "http://experiment.worldcat.org/entity/work/data/1859790419#Agent/delacorte_press_seymour_lawrence",
+    "workExample" : [ "http://worldcat.org/isbn/9780385294201", "http://worldcat.org/isbn/9780385294164" ],
+    "describedby" : "http://www.worldcat.org/title/-/oclc/11866009"
+  }, {
+    "@id" : "http://www.worldcat.org/oclc/559361680",
+    "@type" : "schema:CreativeWork",
+    "description" : "Online version:",
+    "isSimilarTo" : "http://www.worldcat.org/oclc/11866009",
+    "label" : "Galápagos."
+  }, {
+    "@id" : "http://www.worldcat.org/title/-/oclc/11866009",
+    "@type" : [ "genont:ContentTypeGenericResource", "genont:InformationResource" ],
+    "inDataset" : "http://purl.oclc.org/dataset/WorldCat",
+    "about" : "http://www.worldcat.org/oclc/11866009",
+    "dateModified" : "2016-02-11"
+  }, {
+    "@id" : "http://www.worldcat.org/title/-/oclc/11866009#Audience",
+    "@type" : "schema:PeopleAudience",
+    "audienceType" : {
+      "@language" : "en",
+      "@value" : "Juvenile"
+    }
+  }, {
+    "@id" : "http://www.worldcat.org/title/-/oclc/11866009#PublicationEvent/new_york_n_y_delacorte_press_seymour_lawrence_1985",
+    "@type" : "schema:PublicationEvent",
+    "location" : "http://experiment.worldcat.org/entity/work/data/1859790419#Place/new_york_n_y",
+    "organizer" : "http://experiment.worldcat.org/entity/work/data/1859790419#Agent/delacorte_press_seymour_lawrence"
+  } ],
+  "@context" : {
+    "bookFormat" : {
+      "@id" : "http://schema.org/bookFormat",
+      "@type" : "@id"
+    },
+    "name" : "http://schema.org/name",
+    "workExample" : {
+      "@id" : "http://schema.org/workExample",
+      "@type" : "@id"
+    },
+    "isSimilarTo" : {
+      "@id" : "http://schema.org/isSimilarTo",
+      "@type" : "@id"
+    },
+    "inLanguage" : "http://schema.org/inLanguage",
+    "placeOfPublication" : {
+      "@id" : "http://purl.org/library/placeOfPublication",
+      "@type" : "@id"
+    },
+    "describedby" : {
+      "@id" : "http://www.w3.org/2007/05/powder-s#describedby",
+      "@type" : "@id"
+    },
+    "about" : {
+      "@id" : "http://schema.org/about",
+      "@type" : "@id"
+    },
+    "publisher" : {
+      "@id" : "http://schema.org/publisher",
+      "@type" : "@id"
+    },
+    "creator" : {
+      "@id" : "http://schema.org/creator",
+      "@type" : "@id"
+    },
+    "publication" : {
+      "@id" : "http://schema.org/publication",
+      "@type" : "@id"
+    },
+    "datePublished" : "http://schema.org/datePublished",
+    "copyrightYear" : "http://schema.org/copyrightYear",
+    "bookEdition" : "http://schema.org/bookEdition",
+    "audience" : {
+      "@id" : "http://schema.org/audience",
+      "@type" : "@id"
+    },
+    "description" : "http://schema.org/description",
+    "productID" : "http://schema.org/productID",
+    "exampleOfWork" : {
+      "@id" : "http://schema.org/exampleOfWork",
+      "@type" : "@id"
+    },
+    "oclcnum" : "http://purl.org/library/oclcnum",
+    "genre" : "http://schema.org/genre",
+    "label" : "http://www.w3.org/2000/01/rdf-schema#label",
+    "identifier" : "http://purl.org/dc/terms/identifier",
+    "location" : {
+      "@id" : "http://schema.org/location",
+      "@type" : "@id"
+    },
+    "organizer" : {
+      "@id" : "http://schema.org/organizer",
+      "@type" : "@id"
+    },
+    "isbn" : "http://schema.org/isbn",
+    "familyName" : "http://schema.org/familyName",
+    "givenName" : "http://schema.org/givenName",
+    "seeAlso" : {
+      "@id" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+      "@type" : "@id"
+    },
+    "audienceType" : "http://schema.org/audienceType",
+    "dateModified" : "http://schema.org/dateModified",
+    "inDataset" : {
+      "@id" : "http://rdfs.org/ns/void#inDataset",
+      "@type" : "@id"
+    },
+    "schema" : "http://schema.org/",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "genont" : "http://www.w3.org/2006/gen/ont#",
+    "wdrs" : "http://www.w3.org/2007/05/powder-s#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+    "library" : "http://purl.org/library/",
+    "void" : "http://rdfs.org/ns/void#",
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "bgn" : "http://bibliograph.net/",
+    "pto" : "http://www.productontology.org/id/",
+    "dcterms" : "http://purl.org/dc/terms/"
+  }
+}

--- a/tests/test_oclc.py
+++ b/tests/test_oclc.py
@@ -46,7 +46,7 @@ class TestParser(DatabaseTest):
 
         eq_(25, len(swids))
         eq_(['10106023', '10190890', '10360105', '105446800', '10798812', '11065951', '122280617', '12468538', '13206523', '13358012', '13424036', '14135019', '1413894', '153927888', '164732682', '1836574', '22658644', '247734888', '250604212', '26863225', '34644035', '46935692', '474972877', '51088077', '652035540'], sorted(swids))
-        
+
         # For your convenience in verifying what I say in
         # test_extract_multiple_works_with_author_restriction().
         assert '13424036' in swids
@@ -87,7 +87,7 @@ class TestParser(DatabaseTest):
             self._db, xml, title="Dick Moby", title_similarity=0.00000000001)
         eq_(21, len(swids))
 
-        # Add a semicolon to the title we're looking for, and the 
+        # Add a semicolon to the title we're looking for, and the
         # work whose title contains ' ; ' is acceptable again.
         status, swids = OCLCXMLParser.parse(
             self._db, xml, title="Dick ; Moby", title_similarity=0.000000001)
@@ -115,7 +115,7 @@ class TestParser(DatabaseTest):
         [melville], ignore = Contributor.lookup(self._db, name="Melville, Herman")
         status, swids = OCLCXMLParser.parse(
             self._db, xml, languages=["eng"], authors=[melville])
-        
+
         # We picked up 11 of the 25 works in the dataset.
         eq_(11, len(swids))
 
@@ -133,7 +133,7 @@ class TestParser(DatabaseTest):
         eq_("Melville, Herman", melville.name)
 
         eq_(None, OCLCXMLParser.primary_author_from_author_string(
-            self._db, 
+            self._db,
             "Melville, Herman, 1819-1891 [Author] | Hayford, Harrison [Associated name; Editor]"))
 
     def test_extract_single_work(self):
@@ -165,17 +165,17 @@ class TestParser(DatabaseTest):
         eq_(set([
             'Cliffs Notes, Inc.',
             'Kent, Rockwell',
-            'Hayford, Harrison', 
+            'Hayford, Harrison',
             'Melville, Herman',
-            'Parker, Hershel', 
+            'Parker, Hershel',
             'Tanner, Tony',
              ]), set(work_contributors))
 
         # Most of the contributors have LC and VIAF numbers, but two
         # (Cliffs Notes and Rockwell Kent) do not.
         eq_(
-            [None, None, u'n50025038', u'n50025038', u'n50050335', 
-             u'n79006936', u'n79059764', u'n79059764', u'n79059764', 
+            [None, None, u'n50025038', u'n50025038', u'n50050335',
+             u'n79006936', u'n79059764', u'n79059764', u'n79059764',
              u'n79059764'],
             sorted([x.lc for x in work.contributors]))
         eq_(
@@ -219,9 +219,9 @@ class TestParser(DatabaseTest):
             ('Ahab, Captain (Fictitious character)', '801923', 29933),
             ('Mentally ill', '1016699', 17294),
             ('Moby Dick (Melville, Herman)', '1356235', 4512),
-            ('Sea stories', '1110122', 6893), 
-            ('Ship captains', '1116147', 19086), 
-            ('Whales', '1174266', 31482), 
+            ('Sea stories', '1110122', 6893),
+            ('Ship captains', '1116147', 19086),
+            ('Whales', '1174266', 31482),
             ('Whaling', '1174284', 32058),
             ('Whaling ships', '1174307', 18913)
         ]
@@ -253,7 +253,7 @@ class TestAuthorParser(DatabaseTest):
 
     MISSING = object()
 
-    def assert_author(self, result, name, role=Contributor.AUTHOR_ROLE, 
+    def assert_author(self, result, name, role=Contributor.AUTHOR_ROLE,
                       birthdate=None, deathdate=None):
         contributor, roles = result
         eq_(contributor.name, name)
@@ -270,7 +270,7 @@ class TestAuthorParser(DatabaseTest):
         elif deathdate:
             eq_(deathdate, contributor.extra[Contributor.DEATH_DATE])
 
-    def assert_parse(self, string, name, role=Contributor.AUTHOR_ROLE, 
+    def assert_parse(self, string, name, role=Contributor.AUTHOR_ROLE,
                      birthdate=None, deathdate=None):
         [res] = OCLCXMLParser.parse_author_string(self._db, string)
         self.assert_author(res, name, role, birthdate, deathdate)
@@ -353,7 +353,7 @@ class TestOCLCLinkedData(TestParser):
     def test_creator_names_picks_up_contributors(self):
         graph = json.loads(
             self.sample_data("no_author_only_contributor.jsonld"))['@graph']
-        
+
         eq_(([], []), OCLCLinkedData.creator_names(graph))
         eq_((['Thug Kitchen LLC.'], []),
             OCLCLinkedData.creator_names(graph, 'contributor'))

--- a/tests/test_oclc.py
+++ b/tests/test_oclc.py
@@ -394,6 +394,7 @@ class TestOCLCLinkedData(TestParser):
         eq_(1, len(metadata_obj.contributors))
         [viaf] = [c.viaf for c in metadata_obj.contributors]
         eq_(u"71398958", viaf)
+        eq_(4, len(metadata_obj.subjects))
 
 
 class TestLinkedDataCoverageProvider(DatabaseTest):

--- a/tests/test_oclc.py
+++ b/tests/test_oclc.py
@@ -391,6 +391,10 @@ class TestOCLCLinkedData(TestParser):
         assert "ghost of a shipbuilder" in metadata_obj.links[0].content
         eq_(4, len(metadata_obj.identifiers))
 
+        eq_(1, len(metadata_obj.contributors))
+        [viaf] = [c.viaf for c in metadata_obj.contributors]
+        eq_(u"71398958", viaf)
+
 
 class TestLinkedDataCoverageProvider(DatabaseTest):
 


### PR DESCRIPTION
This combines the (now-dead) `#info_for_book_graph` method with the `#book_info_to_metadata` method. Super-cool.

It also fixes a couple parsing things to make sure we're pulling in all the subject information and VIAF ids we can handle.

My only concern is that the #extract_useful_data method doesn't appear to be pulling in publisher information or tags / genres anymore. I'll make an issue for it and follow-up.

Fixes #32.