### PR TITLE
Fix oclc extraction

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -179,6 +179,7 @@ class IdentifierResolutionMonitor(CoreIdentifierResolutionMonitor):
                 edition.equivalent_identifiers(type=types)
             )
         for oclc_id in oclc_ids:
+            self.log.info("Currently processing equivalent identifier: %r", oclc_id)
             self.oclc_linked_data.ensure_coverage(oclc_id)
 
     def resolve_viaf(self, work):

--- a/oclc.py
+++ b/oclc.py
@@ -172,11 +172,11 @@ class OCLCLinkedData(object):
     ])
 
     FILTER_TAGS = POINTLESS_TAGS.union(TAGS_FOR_UNUSABLE_RECORDS)
+    log = logging.getLogger("OCLC Linked Data Client")
 
     def __init__(self, _db):
         self._db = _db
         self.source = DataSource.lookup(self._db, DataSource.OCLC_LINKED_DATA)
-        self.log = logging.getLogger("OCLC Linked Data Client")
 
     def lookup(self, identifier_or_uri, processed_uris=set()):
         """Perform an OCLC Open Data lookup for the given identifier."""
@@ -383,6 +383,7 @@ class OCLCLinkedData(object):
         else:
             return no_value
 
+        cls.log.info("Extracting %s: %s", id_type, id)
         for k, repository in (
                 ('schema:description', descriptions),
                 ('description', descriptions),
@@ -515,10 +516,6 @@ class OCLCLinkedData(object):
 
         :returns: None if information is unhelpful; metadata object otherwise.
         """
-        self.log.info(
-            "Processing edition %s: %r", book_info.get('oclc_id'),
-            book_info.get('titles')
-        )
         if not self._has_relevant_types(book_info):
             # This book is not available in any format we're
             # interested in from a metadata perspective.
@@ -537,6 +534,7 @@ class OCLCLinkedData(object):
         if not oclc_id_type or not oclc_id:
             return None
 
+        self.log.info("Processing edition %s: %r", oclc_id, titles)
         metadata = Metadata(self.source)
         metadata.primary_identifier, new = Identifier.for_foreign_id(
             self._db, oclc_id_type, oclc_id

--- a/oclc.py
+++ b/oclc.py
@@ -409,7 +409,6 @@ class OCLCLinkedData(object):
                 continue
 
             # Initialize subject details
-            [subject_data] = cls.internal_lookup(subgraph, [uri])
             subject_type = None
             subject_id = None
             subject_name = None
@@ -423,15 +422,23 @@ class OCLCLinkedData(object):
                     subject_type = canonical_subject_type
                     break
 
-            # Subject doesn't match known classification systems. Try to
-            # identify the subject type another way.
+            # Try to pull information from an internal lookup.
+            internal_lookup = cls.internal_lookup(subgraph, [uri])
+            if not internal_lookup:
+                # There's no extra data to be had. Take the subject and run.
+                if subject_id and subject_type:
+                    subjects[subject_type].append(dict(id=subject_id))
+                continue
+            [subject_data] = internal_lookup
+
+            # Subject doesn't match known classification systems. Look
+            # for an acceptable type.
             if not subject_type:
                 type_objs = []
                 for type_property in ('rdf:type', '@type'):
                     potential_types = subject_data.get(type_property, [])
                     if not isinstance(potential_types, list):
                         potential_types = [potential_types]
-
                     for potential_type in potential_types:
                         if isinstance(potential_type, dict):
                             type_objs.append(potential_type)

--- a/oclc.py
+++ b/oclc.py
@@ -400,7 +400,7 @@ class OCLCLinkedData(object):
             ))
 
         genres = book.get('genre', [])
-        genres = [x for x in ldq.values(ldq.restrict_to_language(genres, 'en'))]
+        genres = list(ldq.values(ldq.restrict_to_language(genres, 'en')))
         genres = set(filter(None, [cls._fix_tag(tag) for tag in genres]))
         subjects[Subject.TAG] = [dict(id=genre) for genre in genres]
 
@@ -408,11 +408,7 @@ class OCLCLinkedData(object):
             if not isinstance(uri, basestring):
                 continue
 
-            # Initialize subject details
-            subject_type = None
-            subject_id = None
-            subject_name = None
-            name_value = None
+            subject_id = subject_type = subject_name = None
 
             # Grab FAST, DDC, and LCSH identifiers & types from their URIs.
             for r, canonical_subject_type in cls.URI_TO_SUBJECT_TYPE.items():
@@ -455,13 +451,14 @@ class OCLCLinkedData(object):
 
             # Grab a human-readable name if possible.
             if subject_type:
+                subject_names = None
                 for name_property in ('name', 'schema:name'):
                     if name_property in subject_data:
-                        name_value = [value for value in ldq.values(
-                            ldq.restrict_to_language(subject_data[name_property], 'en')
-                        )]
-                    if name_value:
-                        [subject_name] = name_value
+                        subject_names = list(ldq.values(ldq.restrict_to_language(
+                            subject_data[name_property], 'en'
+                        )))
+                    if subject_names:
+                        subject_name = subject_names[0]
                         break
 
                 # Set ids or names as appropriate & add to the list.

--- a/tests/files/oclc/galapagos.jsonld
+++ b/tests/files/oclc/galapagos.jsonld
@@ -58,7 +58,7 @@
   }, {
     "@id" : "http://id.worldcat.org/fast/1219610",
     "@type" : "schema:Place",
-    "name" : "Galapagos Islands."
+    "name" : ["Galapagos Islands.", "Galapagos Islands"]
   }, {
     "@id" : "http://viaf.org/viaf/71398958",
     "@type" : "schema:Person",
@@ -78,7 +78,7 @@
     "@type" : [ "schema:CreativeWork", "schema:Book" ],
     "oclcnum" : "11866009",
     "placeOfPublication" : [ "http://experiment.worldcat.org/entity/work/data/1859790419#Place/new_york_n_y", "http://id.loc.gov/vocabulary/countries/nyu" ],
-    "about" : [ "http://experiment.worldcat.org/entity/work/data/1859790419#Topic/islands", "http://dewey.info/class/813.54/e19/", "http://id.worldcat.org/fast/1219610", "http://id.loc.gov/authorities/subjects/sh85062975", "http://experiment.worldcat.org/entity/work/data/1859790419#Topic/satirical_fiction", "http://experiment.worldcat.org/entity/work/data/1859790419#Place/galapagos_islands", "http://id.loc.gov/authorities/subjects/sh85118637", "http://experiment.worldcat.org/entity/work/data/1859790419#Topic/ghosts" ],
+    "about" : [ "http://experiment.worldcat.org/entity/work/data/1859790419#Topic/islands", "http://dewey.info/class/813.54/e19/", "http://id.worldcat.org/fast/1219610", "http://id.loc.gov/authorities/subjects/sh85062975", "http://experiment.worldcat.org/entity/work/data/1859790419#Topic/satirical_fiction", "http://experiment.worldcat.org/entity/work/data/1859790419#Place/galapagos_islands", "http://id.loc.gov/authorities/subjects/sh85118637", "http://experiment.worldcat.org/entity/work/data/1859790419#Topic/ghosts", "http://subject.example.wo/internal_lookup", "http://id.loc.gov/authorities/subjects/sh12345678" ],
     "audience" : "http://www.worldcat.org/title/-/oclc/11866009#Audience",
     "bookEdition" : "1st trade ed.",
     "bookFormat" : "bgn:PrintBook",

--- a/tests/test_oclc.py
+++ b/tests/test_oclc.py
@@ -386,11 +386,19 @@ class TestOCLCLinkedData(TestParser):
         eq_(u"11866009", oclc_id)
         eq_([u"Galápagos : a novel"], titles)
         eq_(1, len(descriptions))
+
+        # Even though there are 11 links in the books "about" list,
+        # "http://subject.example.wo/internal_lookup" does not get included as
+        # a subject because it doesn't have an internal lookup.
         eq_(1, len(subjects[Subject.DDC]))
         eq_(1, len(subjects[Subject.FAST]))
         eq_(4, len(subjects[Subject.TAG]))
         eq_(1, len(subjects[Subject.PLACE]))
+        # Meanwhile, the made-up LCSH subject that also doesn't have an
+        # internal lookup is included because its details can be parsed from
+        # the url: "http://id.loc.gov/authorities/subjects/sh12345678"
         eq_(3, len(subjects[Subject.LCSH]))
+
         eq_(1, len(creator_uris))
         eq_(["Delacorte Press/Seymour Lawrence"], publishers)
         eq_(["1985"], publication_dates)

--- a/tests/test_oclc.py
+++ b/tests/test_oclc.py
@@ -390,7 +390,7 @@ class TestOCLCLinkedData(TestParser):
         eq_(1, len(subjects[Subject.FAST]))
         eq_(4, len(subjects[Subject.TAG]))
         eq_(1, len(subjects[Subject.PLACE]))
-        eq_(2, len(subjects[Subject.LCSH]))
+        eq_(3, len(subjects[Subject.LCSH]))
         eq_(1, len(creator_uris))
         eq_(["Delacorte Press/Seymour Lawrence"], publishers)
         eq_(["1985"], publication_dates)
@@ -421,7 +421,7 @@ class TestOCLCLinkedData(TestParser):
         eq_(1, len(metadata_obj.contributors))
         [viaf] = [c.viaf for c in metadata_obj.contributors]
         eq_(u"71398958", viaf)
-        eq_(9, len(metadata_obj.subjects))
+        eq_(10, len(metadata_obj.subjects))
 
 
 class TestLinkedDataCoverageProvider(DatabaseTest):


### PR DESCRIPTION
This works to fix some of the recurring issues in #41 when an internal lookup isn't returned and when a subject has multiple potential names. I wasn't able to clearly replicate this issue, so I'm primarily going off the errors that are raised. I recreated those errors in the given test file (`tests/files/oclc/galapagos.jsonld`) by adding two subjects that don't have internal lookups: one that matches a known subject URI pattern and one that doesn't.

It also adds some logging to make the relevant cases easier to find in the future.