### PR TITLE
Presentation policy

### DIFF
--- a/bin/repair/work_presentation
+++ b/bin/repair/work_presentation
@@ -5,11 +5,5 @@ import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
-from scripts import WorkPresentationCalculationScript
-
-args = list(sys.argv[1:])
-force = False
-if 'force' in args:
-   force = True
-   args.remove('force')
-WorkPresentationCalculationScript(force=force).run()
+from core.scripts import WorkPresentationScript
+WorkPresentationScript().run()

--- a/oclc.py
+++ b/oclc.py
@@ -1282,6 +1282,14 @@ class LinkedDataCoverageProvider(CoverageProvider):
 
             for metadata in self.api.info_for(identifier):
                 oclc_editions = metadata.primary_identifier.primarily_identifies
+
+                # Keep track of the number of editions OCLC associates
+                # with this identifier.
+                metadata.primary_identifier.add_measurement(
+                    self.output_source, Measurement.PUBLISHED_EDITIONS, 
+                    len(oclc_editions)
+                )
+
                 num_new_isbns = self.new_isbns(metadata)
                 if oclc_editions:
                     for edition in oclc_editions:

--- a/scripts.py
+++ b/scripts.py
@@ -8,6 +8,7 @@ from core.model import (
     Edition,
     Equivalency,
     Identifier,
+    PresentationCalculationPolicy,
     Subject,
     UnresolvedIdentifier,
     Work,
@@ -82,19 +83,6 @@ class FillInVIAFAuthorNames(Script):
     def run(self):
         """Fill in all author names with information from VIAF."""
         VIAFClient(self._db).run(self.force)
-
-
-class WorkPresentationCalculationScript(WorkProcessingScript):
-
-    def process_work(self, work):
-        work.calculate_presentation(
-            choose_edition=False, classify=True, choose_summary=True,
-            calculate_quality=True)
-
-    def query_hook(self, q):
-        if not self.force:
-            q = q.filter(Work.fiction==None).filter(Work.audience==None)
-        return q
 
 
 class CoverImageMirrorScript(Script):

--- a/scripts.py
+++ b/scripts.py
@@ -8,7 +8,6 @@ from core.model import (
     Edition,
     Equivalency,
     Identifier,
-    PresentationCalculationPolicy,
     Subject,
     UnresolvedIdentifier,
     Work,


### PR DESCRIPTION
This branch brings the metadata wrangler up-to-date with the changes in https://github.com/NYPL-Simplified/server_core/pull/132.

* The code that derives a measurement of popularity from the number of editions of a book OCLC knows about has been moved from core into LinkedDataCoverageProvider.process_item. I'm not 100% sure this is the right place for this but I think so.

* The WorkPresentationCalculationScript has been removed in favor of the PresentationCalculationScript in core.