### PR TITLE
Improve metadata policy

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -69,10 +69,7 @@ class IdentifierResolutionMonitor(CoreIdentifierResolutionMonitor):
         # We're going to be aggressive about recalculating the presentation
         # for this work because either the work is currently not set up
         # at all, or something went wrong trying to set it up.
-        presentation_calculation_policy = PresentationCalculationPolicy(
-            regenerate_opds_entries=True,
-            update_search_index=True
-        )
+        presentation_calculation_policy = PresentationCalculationPolicy.recalculate_everything()
         policy = ReplacementPolicy.from_metadata_source(
             mirror=mirror, even_if_not_apparently_updated=True,
             presentation_calculation_policy=presentation_calculation_policy


### PR DESCRIPTION
This branch improves the metadata wrangler's IdentifierResolutionMonitor so that cover images are automatically mirrored to S3 and scaled, and so the presentation of a work processed by the IdentifierResolutionMonitor is fully recalculated, even if it doesn't seem necessary. It's a follow-up to https://github.com/NYPL-Simplified/server_core/pull/152.