### PR TITLE
Show collection updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ class Conf:
         cls.db = _db
         cls.log = logging.getLogger("Metadata web app")
 
-if os.environ.get('TESTING') == "True":
+if os.environ.get('TESTING') == "true":
     Conf.testing = True
 else:
     Conf.testing = False
@@ -101,6 +101,10 @@ def canonical_author_name():
     else:
         return make_response("", 404)
 
+@app.route('/updates')
+@requires_auth
+def updates():
+    return CollectionController(Conf.db).updates_feed()
 
 if __name__ == '__main__':
 

--- a/controller.py
+++ b/controller.py
@@ -40,7 +40,6 @@ class CollectionController(object):
         if isinstance(collection, ProblemDetail):
             return collection
 
-        # Record time of update check before initiating database query.
         last_update_time = flask.request.args.get('last_update_time', None)
         if last_update_time:
             last_update_time = datetime.strptime(last_update_time, "%Y-%m-%dT%H:%M:%SZ")
@@ -49,8 +48,10 @@ class CollectionController(object):
         pagination = load_pagination_from_request()
         works = pagination.apply(updated_works).all()
         title = "%s Updates" % collection.name
-        def update_url(page=None):
+        def update_url(time=last_update_time, page=None):
             kw = dict(_external=True)
+            if time:
+                kw.update({'last_update_time' : last_update_time})
             if page:
                 kw.update(page.items())
             return cdn_url_for("updates", **kw)

--- a/controller.py
+++ b/controller.py
@@ -7,6 +7,11 @@ from core.app_server import (
     feed_response,
 )
 from core.model import Collection
+from core.opds import (
+    AcquisitionFeed,
+    VerboseAnnotator,
+)
+from core.util.problem_detail import ProblemDetail
 from core.problem_details import INVALID_CREDENTIALS
 
 
@@ -28,3 +33,22 @@ class CollectionController(object):
             # (i.e. URN lookup) return None instead of an error.
             return None
         return INVALID_CREDENTIALS
+
+    def updates_feed(self):
+        collection = self.authenticated_collection_from_request()
+        if isinstance(collection, ProblemDetail):
+            return collection
+
+        update_url = cdn_url_for('updates', _external=True)
+        # Record time of update check before initiating database query.
+        updated_at = datetime.utcnow()
+        updated_works = collection.works_updated(self._db)
+        collection.last_checked = updated_at
+        self._db.commit()
+
+        feed_title = "%s Updates" % collection.name
+        update_feed = AcquisitionFeed(
+            self._db, feed_title, update_url, updated_works,
+            VerboseAnnotator
+        )
+        return feed_response(update_feed)

--- a/controller.py
+++ b/controller.py
@@ -41,10 +41,10 @@ class CollectionController(object):
             return collection
 
         # Record time of update check before initiating database query.
-        updated_at = datetime.utcnow()
-        updated_works = collection.works_updated(self._db)
-        collection.last_checked = updated_at
-        self._db.commit()
+        last_update_time = flask.request.args.get('last_update_time', None)
+        if last_update_time:
+            last_update_time = datetime.strptime(last_update_time, "%Y-%m-%dT%H:%M:%SZ")
+        updated_works = collection.works_updated_since(self._db, last_update_time)
 
         pagination = load_pagination_from_request()
         works = pagination.apply(updated_works).all()

--- a/controller.py
+++ b/controller.py
@@ -1,0 +1,30 @@
+import flask
+from nose.tools import set_trace
+from datetime import datetime
+
+from core.app_server import (
+    cdn_url_for,
+    feed_response,
+)
+from core.model import Collection
+from core.problem_details import INVALID_CREDENTIALS
+
+
+class CollectionController(object):
+    """A controller to manage collections and their assets"""
+
+    def __init__(self, _db):
+        self._db = _db
+
+    def authenticated_collection_from_request(self, required=True):
+        header = flask.request.authorization
+        if header:
+            client_id, client_secret = header.username, header.password
+            collection = Collection.authenticate(self._db, client_id, client_secret)
+            if collection:
+                return collection
+        if not required and not header:
+            # In the case that authentication is not required
+            # (i.e. URN lookup) return None instead of an error.
+            return None
+        return INVALID_CREDENTIALS

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -83,13 +83,17 @@ class TestCollectionController(DatabaseTest):
             eq_(identifier.urn, entry['id'])
 
         # A time can be passed.
-        timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        time = datetime.utcnow()
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ")
         with self.app.test_request_context('/?last_update_time=%s' % timestamp,
                 headers=dict(Authorization=self.valid_auth)):
             response = self.controller.updates_feed()
             eq_(200, response.status_code)
             feed = feedparser.parse(response.get_data())
             eq_(feed['feed']['title'],"%s Updates" % self.collection.name)
+            # The timestamp is included in the url.
+            linkified_timestamp = time.strftime("%Y-%m-%d+%H:%M:%S").replace(":", "%3A")
+            assert feed['feed']['id'].endswith(linkified_timestamp)
             # And only works updated since the timestamp are returned.
             eq_(0, len(feed['entries']))
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -98,3 +98,7 @@ class TestCollectionController(DatabaseTest):
             [entry] = feed['entries']
             eq_(w2.title, entry['title'])
             eq_(w2_identifier.urn, entry['id'])
+
+        # The last update timestamp has been updated.
+        eq_(True, self.collection.last_checked != previous_check)
+        eq_(True, self.collection.last_checked > previous_check)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,100 @@
+import os
+import base64
+import feedparser
+from nose.tools import set_trace, eq_
+
+from . import DatabaseTest
+from ..core.model import DataSource
+from ..core.util.problem_detail import ProblemDetail
+
+from ..controller import CollectionController
+
+class TestCollectionController(DatabaseTest):
+
+    def setup(self):
+        super(TestCollectionController, self).setup()
+        from ..app import app
+        self.app = app
+
+        self.controller = CollectionController(self._db)
+        self.collection = self._collection()
+        self.valid_auth = 'Basic ' + base64.b64encode('abc:def')
+
+    def test_authenticated_collection_required(self):
+        # Returns collection if authentication is valid.
+        with self.app.test_request_context('/',
+                headers=dict(Authorization=self.valid_auth)):
+            result = self.controller.authenticated_collection_from_request()
+            eq_(result, self.collection)
+        
+        # Returns error if authentication is invalid.
+        invalid_auth = 'Basic ' + base64.b64encode('abc:defg')
+        with self.app.test_request_context('/',
+                headers=dict(Authorization=invalid_auth)):
+            result = self.controller.authenticated_collection_from_request()
+            eq_(True, isinstance(result, ProblemDetail))
+            eq_(401, result.status_code)
+
+        # Returns errors without authentication.
+        with self.app.test_request_context('/'):
+            result = self.controller.authenticated_collection_from_request()
+            eq_(True, isinstance(result, ProblemDetail))
+
+    def test_authenticated_collection_optional(self):
+        # Returns collection of authentication is valid.
+        with self.app.test_request_context('/',
+                headers=dict(Authorization=self.valid_auth)):
+            result = self.controller.authenticated_collection_from_request(required=False)
+            eq_(result, self.collection)
+        
+        # Returns error if attempted authentication is invalid.
+        invalid_auth = 'Basic ' + base64.b64encode('abc:defg')
+        with self.app.test_request_context('/',
+                headers=dict(Authorization=invalid_auth)):
+            result = self.controller.authenticated_collection_from_request(required=False)
+            eq_(True, isinstance(result, ProblemDetail))
+            eq_(401, result.status_code)
+
+        # Returns none if no authentication.
+        with self.app.test_request_context('/'):
+            result = self.controller.authenticated_collection_from_request(required=False)
+            eq_(None, result)
+
+    def test_collection_updates(self):
+        w1 = self._work(with_license_pool=True, with_open_access_download=True)
+        identifier = w1.license_pools[0].identifier
+        self.collection.catalog_identifier(self._db, identifier)
+
+        # Collection hasn't checked its updates at all
+        eq_(None, self.collection.last_checked)
+
+        with self.app.test_request_context('/',
+                headers=dict(Authorization=self.valid_auth)):
+            response = self.controller.updates_feed()
+            eq_(200, response.status_code)
+            feed = feedparser.parse(response.get_data())
+            eq_(feed['feed']['title'],"%s Updates" % self.collection.name)
+            
+            eq_(1, len(feed['entries']))
+            [entry] = feed['entries']
+            eq_(w1.title, entry['title'])
+            eq_(identifier.urn, entry['id'])
+
+        # The collection's last check timestamp has be set
+        assert self.collection.last_checked
+        previous_check = self.collection.last_checked
+
+        # Add another work.
+        w2 = self._work(with_license_pool=True, with_open_access_download=True)
+        w2_identifier = w2.license_pools[0].identifier
+        self.collection.catalog_identifier(self._db, w2_identifier)
+        with self.app.test_request_context('/',
+                headers=dict(Authorization=self.valid_auth)):
+            response = self.controller.updates_feed()
+            eq_(200, response.status_code)
+            feed = feedparser.parse(response.get_data())
+            # Only the second work is in the feed.
+            eq_(1, len(feed['entries']))
+            [entry] = feed['entries']
+            eq_(w2.title, entry['title'])
+            eq_(w2_identifier.urn, entry['id'])


### PR DESCRIPTION
This branch adds some tests for collection authentication -- both when it's optional and when it's required. It also gives the wrangler a new route that collections can hit, which will return only those identifiers updated since their last visit.

Fixes #51.