### PR TITLE
Remove ids from collections

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,7 +106,6 @@ def updates():
 
 @app.route('/remove', methods=['POST'])
 @requires_auth
-@returns_problem_detail
 def remove():
     return CollectionController(Conf.db).remove_items()
 

--- a/app.py
+++ b/app.py
@@ -6,12 +6,12 @@ import urlparse
 
 from functools import wraps
 from flask import Flask, make_response
-from core.util.flask_util import problem
 from core.util.problem_detail import ProblemDetail
 from core.opds import VerboseAnnotator
 from core.app_server import (
     HeartbeatController,
     URNLookupController,
+    returns_problem_detail,
 )
 from core.model import (
     production_session,
@@ -74,16 +74,14 @@ def lookup(collection=None):
     )
 
 @app.route('/canonical-author-name')
+@returns_problem_detail
 def canonical_author_name():
     urn = flask.request.args.get('urn')
     display_name = flask.request.args.get('display_name')
     if urn:
         identifier = URNLookupController.parse_urn(Conf.db, urn, False)
         if not isinstance(identifier, Identifier):
-            # Error.
-            status, title = identifier
-            type = URNLookupController.COULD_NOT_PARSE_URN_TYPE
-            return problem(type, status, title)
+            return INVALID_URN
     else:
         identifier = None
 

--- a/app.py
+++ b/app.py
@@ -104,6 +104,12 @@ def canonical_author_name():
 def updates():
     return CollectionController(Conf.db).updates_feed()
 
+@app.route('/remove', methods=['POST'])
+@requires_auth
+@returns_problem_detail
+def remove():
+    return CollectionController(Conf.db).remove_items()
+
 if __name__ == '__main__':
 
     debug = True

--- a/controller.py
+++ b/controller.py
@@ -1,6 +1,6 @@
-import flask
 from nose.tools import set_trace
 from datetime import datetime
+from flask import request, make_response
 
 from core.app_server import (
     cdn_url_for,
@@ -23,7 +23,7 @@ class CollectionController(object):
         self._db = _db
 
     def authenticated_collection_from_request(self, required=True):
-        header = flask.request.authorization
+        header = request.authorization
         if header:
             client_id, client_secret = header.username, header.password
             collection = Collection.authenticate(self._db, client_id, client_secret)
@@ -40,7 +40,7 @@ class CollectionController(object):
         if isinstance(collection, ProblemDetail):
             return collection
 
-        last_update_time = flask.request.args.get('last_update_time', None)
+        last_update_time = request.args.get('last_update_time', None)
         if last_update_time:
             last_update_time = datetime.strptime(last_update_time, "%Y-%m-%dT%H:%M:%SZ")
         updated_works = collection.works_updated_since(self._db, last_update_time)

--- a/controller.py
+++ b/controller.py
@@ -16,7 +16,10 @@ from core.opds import (
     VerboseAnnotator,
 )
 from core.util.problem_detail import ProblemDetail
-from core.problem_details import *
+from core.problem_details import (
+    INVALID_CREDENTIALS,
+    INVALID_URN,
+)
 
 
 class CollectionController(object):


### PR DESCRIPTION
This branch allows a collection client to remove identifiers from its catalog as they are no longer included. It also moves the Wrangler slightly closer to the Circulation Manager's way of doing things, including using some of its bits, newly transferred to core: NYPL-Simplified/server_core#200.

Fixes #54.