### PR TITLE
Bring metadata up to date with latest core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ python-dateutil
 loggly-python-handler
 mock
 cairosvg
-bcrypt
 
 # Used only by metadata
 pyld

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ python-dateutil
 loggly-python-handler
 mock
 cairosvg
+bcrypt
 
 # Used only by metadata
 pyld

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,20 +3,7 @@ from nose.tools import set_trace
 
 from ..core.testing import (
     DatabaseTest,
-    _setup,
-    _teardown,
+    package_setup,
 )
 
-class MetadataDBInfo(object):
-    connection = None
-    engine = None
-    transaction = None
-
-DatabaseTest.DBInfo = MetadataDBInfo
-
-def setup():
-    _setup(MetadataDBInfo)
-
-def teardown():
-    _teardown(MetadataDBInfo)
-
+package_setup()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -60,13 +60,17 @@ class TestRedoOCLCForThreeM(DatabaseTest):
         assert self.edition3.primary_identifier not in identifiers
 
     def test_delete_coverage_records(self):
-        coverage_records_before = self._db.query(CoverageRecord).all()
+        oclc = DataSource.lookup(self._db, DataSource.OCLC_LINKED_DATA)
+        q = self._db.query(CoverageRecord).filter(
+            CoverageRecord.data_source==oclc
+        )
+        coverage_records_before = q.all()
         eq_(1, len(coverage_records_before))
         eq_(self.edition2.primary_identifier, coverage_records_before[0].identifier)
 
         identifiers = [self.edition1.primary_identifier, self.edition2.primary_identifier]
         self.script.delete_coverage_records(identifiers)
-        coverage_records_after = self._db.query(CoverageRecord).all()
+        coverage_records_after = q.all()
         eq_(0, len(coverage_records_after))
 
     def test_ensure_isbn_identifier(self):


### PR DESCRIPTION
This changes the metadata test runner to use the new test setup system, and improves a test that will otherwise fail once the licensepool-superceded core branch lands.