### PR TITLE
Workset size to batch size

### DIFF
--- a/content_cafe.py
+++ b/content_cafe.py
@@ -37,7 +37,7 @@ class ContentCafeCoverageProvider(CoverageProvider):
         super(ContentCafeCoverageProvider, self).__init__(
             "Content Cafe Coverage Provider",
             self.input_identifier_types, output_source,
-            workset_size=25)
+            batch_size=25)
 
     def process_item(self, identifier):
         try:

--- a/content_server.py
+++ b/content_server.py
@@ -36,7 +36,7 @@ class ContentServerCoverageProvider(CoverageProvider):
         )
         super(ContentServerCoverageProvider, self).__init__(
                 "OA Content Server Coverage Provider",
-                input_identifier_types, output_source, workset_size=10
+                input_identifier_types, output_source, batch_size=10
         )
 
     def process_item(self, identifier):

--- a/novelist.py
+++ b/novelist.py
@@ -321,7 +321,7 @@ class NoveListCoverageProvider(CoverageProvider):
 
         super(NoveListCoverageProvider, self).__init__(
             "NoveList Coverage Provider", [Identifier.ISBN],
-            self.source, workset_size=25
+            self.source, batch_size=25
         )
 
     @property

--- a/oclc.py
+++ b/oclc.py
@@ -1279,7 +1279,7 @@ class LinkedDataCoverageProvider(CoverageProvider):
         ]
         super(LinkedDataCoverageProvider, self).__init__(
             "OCLC Linked Data Coverage Provider", input_identifier_types,
-            output_source, workset_size=10
+            output_source, batch_size=10
         )
 
     def process_item(self, identifier):


### PR DESCRIPTION
This branch updates core and changes the `workset_size` argument used in CoverageProvider constructors to the new name, `batch_size`.