### PR TITLE
Fix identifier resolution

### DIFF
--- a/bin/repair/add_unresolvedidentifiers_for_incomplete_identifiers
+++ b/bin/repair/add_unresolvedidentifiers_for_incomplete_identifiers
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""Add UnresolvedIdentifiers for Identifiers that need them but for 
+whatever reason don't currently have UnresolvedIdentifiers.
+"""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import AddMissingUnresolvedIdentifiersScript
+AddMissingUnresolvedIdentifiersScript().run()

--- a/content_server.py
+++ b/content_server.py
@@ -19,7 +19,9 @@ class ContentServerException(Exception):
     pass
 
 class ContentServerCoverageProvider(CoverageProvider):
-    """Checks the OA Content Server for Records"""
+    """Checks the OA Content Server for metadata about Gutenberg books
+    and books identified by URI.
+    """
 
     CONTENT_SERVER_RETURNED_WRONG_CONTENT_TYPE = "Content Server served unhandleable media type: %s"
 
@@ -57,7 +59,8 @@ class ContentServerCoverageProvider(CoverageProvider):
             return CoverageFailure(
                 identifier,
                 self.CONTENT_SERVER_RETURNED_WRONG_CONTENT_TYPE % (
-                    content_type)
+                    content_type),
+                data_source
             )
         
         editions, licensepools, works, messages = self.importer.import_from_feed(

--- a/content_server.py
+++ b/content_server.py
@@ -12,6 +12,7 @@ from core.coverage import (
     CoverageProvider,
     CoverageFailure,
 )
+from core.util.http import BadResponseException
 
 class ContentServerException(Exception):
     # Raised when the ContentServer can't connect or returns bad data
@@ -20,17 +21,17 @@ class ContentServerException(Exception):
 class ContentServerCoverageProvider(CoverageProvider):
     """Checks the OA Content Server for Records"""
 
-    CONTENT_SERVER_RETURNED_ERROR = "OA Content Server returned error"
-    CONTENT_SERVER_RETURNED_WRONG_CONTENT_TYPE = "Content Server served \
-            unhandleable media type"
+    CONTENT_SERVER_RETURNED_WRONG_CONTENT_TYPE = "Content Server served unhandleable media type: %s"
 
-    def __init__(self, _db):
+    def __init__(self, _db, content_server=None):
         self._db = _db
-        content_server_url = Configuration.integration_url(
-            Configuration.CONTENT_SERVER_INTEGRATION, required=True)
-        self.content_server = SimplifiedOPDSLookup(content_server_url)
+        if not content_server:
+            content_server_url = Configuration.integration_url(
+                Configuration.CONTENT_SERVER_INTEGRATION, required=True)
+            content_server = SimplifiedOPDSLookup(content_server_url)
+        self.content_server = content_server
         self.importer = OPDSImporter(self._db, DataSource.OA_CONTENT_SERVER)
-        input_identifier_types = [Identifier.GUTENBERG_ID]
+        input_identifier_types = [Identifier.GUTENBERG_ID, Identifier.URI]
         output_source = DataSource.lookup(
             self._db, DataSource.OA_CONTENT_SERVER
         )
@@ -40,10 +41,26 @@ class ContentServerCoverageProvider(CoverageProvider):
         )
 
     def process_item(self, identifier):
-        response = self.content_server.lookup([identifier])
-        self.check_response_for_errors(response)
-
-        editions, messages, next_links = self.importer.import_from_feed(
+        data_source = DataSource.lookup(
+            self._db, self.importer.data_source_name
+        )
+        try:
+            response = self.content_server.lookup([identifier])
+        except BadResponseException, e:
+            return CoverageFailure(
+                identifier,
+                e.message,
+                data_source
+            )
+        content_type = response.headers['content-type']
+        if not content_type.startswith("application/atom+xml"):
+            return CoverageFailure(
+                identifier,
+                self.CONTENT_SERVER_RETURNED_WRONG_CONTENT_TYPE % (
+                    content_type)
+            )
+        
+        editions, licensepools, works, messages = self.importer.import_from_feed(
             response.content
         )
         for edition in editions:
@@ -53,35 +70,11 @@ class ContentServerCoverageProvider(CoverageProvider):
             if edition_identifier == identifier:
                 return identifier
         expect = identifier.urn
-        for message_identifier, status_message in messages.items():
-            # Return messages as CoverageFailures.
-            if message_identifier == expect:
-                if status_message.status_code == 200:
-                    exception = "OA Content Server returned success, but \
-                            nothing was imported"
-                    transient = True
-                else:
-                    exception = status_message.message
-                    transient = status_message.transient
-                return CoverageFailure(
-                    self, identifier, exception, transient=transient
-                )
-
-        exception = "404: Identifier %r was not found in %s" % (identifier,
-                self.service_name)
-        return CoverageFailure(self, identifier, exception)
-
-    def check_response_for_errors(self, response):
-        """Raises a server error if a response is not a success.
-
-        TODO: This probably doesn't go here.
-        """
-        if response.status_code != 200:
-            raise ContentServerException(self.CONTENT_SERVER_RETURNED_ERROR)
-
-        content_type = response.headers['content-type']
-        if not content_type.startswith("application/atom+xml"):
-            raise ContentServerException(
-                self.CONTENT_SERVER_RETURNED_WRONG_CONTENT_TYPE % (
-                content_type)
-            )
+        messages = messages.values()
+        if messages:
+            return messages[0]
+        return CoverageFailure(
+            identifier,
+            "Identifier was not mentioned in lookup response",
+            data_source
+        )

--- a/scripts.py
+++ b/scripts.py
@@ -23,6 +23,7 @@ from threem import (
 from gutenberg import OCLCClassifyCoverageProvider
 from core.scripts import (
     Explain,
+    IdentifierInputScript,
     WorkProcessingScript,
     Script,
     RunMonitorScript,
@@ -30,7 +31,7 @@ from core.scripts import (
 from viaf import VIAFClient
 from core.util.permanent_work_id import WorkIDCalculator
 
-class RunIdentifierResolutionMonitor(RunMonitorScript):
+class RunIdentifierResolutionMonitor(RunMonitorScript, IdentifierInputScript):
     """Run the identifier resolution monitor.
 
     Why not just use RunMonitorScript with the
@@ -52,10 +53,8 @@ class RunIdentifierResolutionMonitor(RunMonitorScript):
     def run(self):
         # Explicitly create UnresolvedIdentifiers for any Identifiers
         # mentioned on the command line.
-        identifiers = self.parse_identifier_list(
-            self._db, sys.argv[1:], autocreate=True
-        )
-        for identifier in identifiers:
+        args = self.parse_command_line(self._db, autocreate=True)
+        for identifier in args.identifiers:
             self.log.info(
                 "Registering UnresolvedIdentifier for %r", identifier
             )

--- a/tests/files/opds/content_server_lookup.opds
+++ b/tests/files/opds/content_server_lookup.opds
@@ -1,0 +1,30 @@
+<feed xmlns:bibframe="http://bibframe.org/vocab/" xmlns:simplified="http://librarysimplified.org/terms/" xmlns:app="http://www.w3.org/2007/app" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom">
+  <id>http://oacontent.alpha.librarysimplified.org/lookup?urn=http%3A%2F%2Fwww.gutenberg.org%2Febooks%2F20201</id>
+  <title>Lookup results</title>
+  <updated>2016-06-14T19:24:27Z</updated>
+  <link href="http://oacontent.alpha.librarysimplified.org/lookup?urn=http%3A%2F%2Fwww.gutenberg.org%2Febooks%2F20201" rel="self"/>
+  <entry schema:additionalType="http://schema.org/Book">
+    <id>http://www.gutenberg.org/ebooks/20201</id>
+    <title>Mary Gray</title>
+    <bibframe:distribution bibframe:ProviderName="Gutenberg"/>
+    <author>
+      <name/>
+      <simplified:sort_name>Tynan, Katharine</simplified:sort_name>
+    </author>
+    <updated>2016-01-25T15:17:46Z</updated>
+    <simplified:pwid>e05f1380-5e6b-82f6-70ee-539507f82520</simplified:pwid>
+    <link href="http://s3.amazonaws.com/book-covers.nypl.org/Gutenberg%20Illustrated/20201/cover_20201_0.png" type="image/png" rel="http://opds-spec.org/image"/>
+    <link href="http://s3.amazonaws.com/book-covers.nypl.org/Gutenberg%20Illustrated/20201/cover_20201_0.png" type="image/png" rel="http://opds-spec.org/image/thumbnail"/>
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult"/>
+    <category schema:ratingValue="1" term="Poor families -- Fiction" scheme="http://purl.org/dc/terms/LCSH"/>
+    <category schema:ratingValue="1" term="Fathers and daughters -- Fiction" scheme="http://purl.org/dc/terms/LCSH"/>
+    <category schema:ratingValue="1" term="England -- Social life and customs -- Fiction" scheme="http://purl.org/dc/terms/LCSH"/>
+    <category schema:ratingValue="1" term="Rich people -- Fiction" scheme="http://purl.org/dc/terms/LCSH"/>
+    <category schema:ratingValue="1" term="PR" scheme="http://purl.org/dc/terms/LCC"/>
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Project Gutenberg</dcterms:publisher>
+    <published>2015-02-11T15:53:31Z</published>
+    <dcterms:created>2006-12-27</dcterms:created>
+    <link href="http://s3.amazonaws.com/oabooks.nypl.org/Gutenberg%20ID/20201.epub" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
+  </entry>
+</feed>

--- a/tests/files/opds/no_such_work.opds
+++ b/tests/files/opds/no_such_work.opds
@@ -1,0 +1,12 @@
+<feed xmlns:bibframe="http://bibframe.org/vocab/" xmlns:simplified="http://librarysimplified.org/terms/" xmlns:app="http://www.w3.org/2007/app" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom">
+  <id>http://oacontent.alpha.librarysimplified.org/lookup?urn=http%3A%2F%2Fwww.gutenberg.org%2Febooks%2F2020110</id>
+  <title>Lookup results</title>
+  <updated>2016-06-14T20:02:55Z</updated>
+  <link href="http://oacontent.alpha.librarysimplified.org/lookup?urn=http%3A%2F%2Fwww.gutenberg.org%2Febooks%2F2020110" rel="self"/>
+  <entry>
+    <id>http://www.gutenberg.org/ebooks/2020110</id>
+    <simplified:status_code>404</simplified:status_code>
+    <simplified:message>I've never heard of this work.</simplified:message>
+  </entry>
+</feed>
+

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -110,3 +110,4 @@ class TestContentServerCoverageProvider(DatabaseTest):
         eq_("Content Server served unhandleable media type: text/plain",
             failure.exception)
         eq_(True, failure.transient)
+        eq_(DataSource.OA_CONTENT_SERVER, failure.data_source.name)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,112 @@
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+import os
+
+from . import DatabaseTest
+from core.model import (
+    DataSource,
+    Identifier,
+)
+from core.opds_import import MockSimplifiedOPDSLookup
+from content_server import ContentServerCoverageProvider
+
+class TestContentServerCoverageProvider(DatabaseTest):
+
+    def setup(self):
+        super(TestContentServerCoverageProvider, self).setup()
+        self.lookup = MockSimplifiedOPDSLookup("http://url/")
+        self.provider = ContentServerCoverageProvider(
+            self._db, content_server=self.lookup
+        )
+        base_path = os.path.split(__file__)[0]
+        self.resource_path = os.path.join(base_path, "files", "opds")
+
+    def sample_data(self, filename):
+        path = os.path.join(self.resource_path, filename)
+        return open(path).read()
+
+    def test_success(self):
+        data = self.sample_data("content_server_lookup.opds")
+        self.lookup.queue_response(
+            200, {"content-type": "application/atom+xml"},
+            content=data
+        )
+        identifier = self._identifier(identifier_type=Identifier.GUTENBERG_ID)
+
+        # Make the Identifier match the book the queued-up response is
+        # talking about
+        identifier.identifier = "20201"
+        success = self.provider.process_item(identifier)
+        eq_(success, identifier)
+
+        # The book was imported and turned into a Work.
+        work = identifier.licensed_through.work
+        eq_("Mary Gray", work.title)
+
+        # It's not presentation-ready yet, because we are the metadata
+        # wrangler and our work is not yet done.
+        eq_(False, work.presentation_ready)
+
+    def test_no_such_work(self):
+        data = self.sample_data("no_such_work.opds")
+        self.lookup.queue_response(
+            200, {"content-type": "application/atom+xml"},
+            content=data
+        )
+        identifier = self._identifier(identifier_type=Identifier.GUTENBERG_ID)
+
+        # Make the Identifier match the book the queued-up response is
+        # talking about
+        identifier.identifier = "2020110"
+        failure = self.provider.process_item(identifier)
+        eq_(identifier, failure.obj)
+        eq_("404: I've never heard of this work.", failure.exception)
+        eq_(DataSource.OA_CONTENT_SERVER, failure.data_source.name)
+
+        # Most of the time this is a persistent error but it's
+        # possible that we know about a book the content server
+        # doesn't know about yet.
+        eq_(True, failure.transient)
+
+    def test_wrong_work_in_response(self):
+        data = self.sample_data("content_server_lookup.opds")
+        self.lookup.queue_response(
+            200, {"content-type": "application/atom+xml"},
+            content=data
+        )
+        identifier = self._identifier(identifier_type=Identifier.GUTENBERG_ID)
+
+        # The content server told us about a different book than the
+        # one we asked about.
+        identifier.identifier = "999"
+        failure = self.provider.process_item(identifier)
+        eq_(identifier, failure.obj)
+        eq_('Identifier was not mentioned in lookup response', failure.exception)
+        eq_(DataSource.OA_CONTENT_SERVER, failure.data_source.name)
+        eq_(True, failure.transient)
+
+    def test_content_server_http_failure(self):
+        """Test that HTTP-level failures of the content server
+        become transient CoverageFailures.
+        """
+        identifier = self._identifier(identifier_type=Identifier.GUTENBERG_ID)
+
+        self.lookup.queue_response(
+            500, content="help me!"
+        )
+        failure = self.provider.process_item(identifier)
+        eq_(identifier, failure.obj)
+        eq_("Got status code 500 from external server, cannot continue.",
+            failure.exception)
+        eq_(True, failure.transient)
+
+        self.lookup.queue_response(
+            200, {"content-type": "text/plain"}, content="help me!"
+        )
+        failure = self.provider.process_item(identifier)
+        eq_(identifier, failure.obj)
+        eq_("Content Server served unhandleable media type: text/plain",
+            failure.exception)
+        eq_(True, failure.transient)


### PR DESCRIPTION
The identifier resolution monitor has been broken for a while. We didn't notice because it has no test coverage. It has no test coverage because it runs through a bunch of CoverageProviders which themselves have no test coverage.

The purpose of this branch is to make the minimal changes necessary to get the identifier resolution script working again. I also add test coverage to one of the underlying CoverageProviders, and I reduce the amount of code that needs to be covered before we're confident that the identifier resolution script won't break again without us knowing.

