### PR TITLE
Fixed a couple exceptions when getting data from OCLC.

### DIFF
--- a/oclc.py
+++ b/oclc.py
@@ -542,7 +542,8 @@ class OCLCLinkedData(object):
         metadata.primary_identifier, new = Identifier.for_foreign_id(
             self._db, oclc_id_type, oclc_id
         )
-        metadata.title = titles[0]
+        if titles:
+            metadata.title = titles[0]
         for d in publication_dates:
             try:
                 metadata.published = datetime.datetime.strptime(d[:4], "%Y")
@@ -1269,9 +1270,9 @@ class LinkedDataCoverageProvider(CoverageProvider):
     number of ISBNs, which can be used as input into other services.
     """
 
-    def __init__(self, _db):
+    def __init__(self, _db, api=None):
         self._db = _db
-        self.api = OCLCLinkedData(self._db)
+        self.api = api or OCLCLinkedData(self._db)
         output_source = DataSource.lookup(_db, DataSource.OCLC_LINKED_DATA)
         input_identifier_types = [
             Identifier.OCLC_WORK, Identifier.OCLC_NUMBER,
@@ -1332,7 +1333,7 @@ class LinkedDataCoverageProvider(CoverageProvider):
                     self, identifier, exception, transient=False
                 )
             exception = "OCLC raised an error: %r" % e
-            return CoverageFailure(self, identifier, exception, transient=True)
+            return CoverageFailure(identifier, exception, transient=True)
         return identifier
 
     def new_isbns(self, metadata):


### PR DESCRIPTION
This fixes these two exceptions:

```
Traceback (most recent call last):
                    |   File "/home/ec2-user/metadata/core/monitor.py", line 147, in resolve_and_handle_result
                    |     """Resolve one UnresolvedIdentifier."""
                    |   File "/home/ec2-user/metadata/core/monitor.py", line 183, in resolve
                    |     unresolved_identifier.status = status
                    |   File "/home/ec2-user/metadata/monitor.py", line 116, in finalize
                    |     else:
                    |   File "/home/ec2-user/metadata/monitor.py", line 159, in resolve_equivalent_oclc_identifiers
                    |     for contributor in edition.contributors:
                    |   File "/home/ec2-user/metadata/core/coverage.py", line 421, in ensure_coverage
                    |     [identifier]
                    |   File "/home/ec2-user/metadata/core/coverage.py", line 222, in process_batch_and_handle_results
                    |     results = self.process_batch(batch)
                    |   File "/home/ec2-user/metadata/core/coverage.py", line 293, in process_batch
                    |     result = self.process_item(item)
                    |   File "/home/ec2-user/metadata/oclc.py", line 1291, in process_item
                    |     for metadata in self.api.info_for(identifier):
                    |   File "/home/ec2-user/metadata/oclc.py", line 513, in info_for
                    |     info = self.book_info_to_metadata(subgraph, book)
                    |   File "/home/ec2-user/metadata/oclc.py", line 545, in book_info_to_metadata
                    |     metadata.title = titles[0]
                    | IndexError: list index out of range
```

```
| Traceback (most recent call last):
          |   File "/home/ec2-user/metadata/core/monitor.py", line 147, in resolve_and_handle_result
          |     """Resolve one UnresolvedIdentifier."""
          |   File "/home/ec2-user/metadata/core/monitor.py", line 183, in resolve
          |     unresolved_identifier.status = status
          |   File "/home/ec2-user/metadata/monitor.py", line 116, in finalize
          |     else:
          |   File "/home/ec2-user/metadata/monitor.py", line 159, in resolve_equivalent_oclc_identifiers
          |     for contributor in edition.contributors:
          |   File "/home/ec2-user/metadata/core/coverage.py", line 421, in ensure_coverage
          |     [identifier]
          |   File "/home/ec2-user/metadata/core/coverage.py", line 234, in process_batch_and_handle_results
          |     record = self.record_failure_as_coverage_record(item)
          |   File "/home/ec2-user/metadata/core/coverage.py", line 646, in record_failure_as_coverage_record
          |     return failure.to_coverage_record(operation=self.operation)
          |   File "/home/ec2-user/metadata/core/coverage.py", line 44, in to_coverage_record
          |     self.obj, self.data_source, operation=operation
          |   File "/home/ec2-user/metadata/core/model.py", line 971, in add_for
          |     _db = Session.object_session(edition)
          |   File "/home/ec2-user/metadata/env/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 77, in object_session
          |     return object_session(instance)
          |   File "/home/ec2-user/metadata/env/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 2787, in object_session
          |     raise exc.UnmappedInstanceError(instance)
          | UnmappedInstanceError: Class 'oclc.LinkedDataCoverageProvider' is not mapped
```