### PR TITLE
If OCLC Linked Data identifies an author by VIAF ID and doesn't provide a name, quickly look up their VIAF ID to find that name.

### DIFF
--- a/oclc.py
+++ b/oclc.py
@@ -38,6 +38,7 @@ from core.metadata_layer import (
 )
 from core.util import MetadataSimilarity
 
+from viaf import VIAFClient
 
 class OCLC(object):
     """Repository for OCLC-related constants."""
@@ -539,8 +540,8 @@ class OCLCLinkedData(object):
 
         self.log.info("Processing edition %s: %r", oclc_id, titles)
         metadata = Metadata(self.source)
-        metadata.primary_identifier, new = Identifier.for_foreign_id(
-            self._db, oclc_id_type, oclc_id
+        metadata.primary_identifier, new = IdentifierData(
+            type=oclc_id_type, identifier=oclc_id
         )
         if titles:
             metadata.title = titles[0]
@@ -1270,9 +1271,10 @@ class LinkedDataCoverageProvider(CoverageProvider):
     number of ISBNs, which can be used as input into other services.
     """
 
-    def __init__(self, _db, api=None):
+    def __init__(self, _db, api=None, viaf_api=None):
         self._db = _db
         self.api = api or OCLCLinkedData(self._db)
+        self.viaf = viaf_api or VIAFClient(self._db)
         output_source = DataSource.lookup(_db, DataSource.OCLC_LINKED_DATA)
         input_identifier_types = [
             Identifier.OCLC_WORK, Identifier.OCLC_NUMBER,
@@ -1290,14 +1292,26 @@ class LinkedDataCoverageProvider(CoverageProvider):
             self.log.info("Processing identifier %r", identifier)
 
             for metadata in self.api.info_for(identifier):
-                oclc_editions = metadata.primary_identifier.primarily_identifies
+                other_identifier, ignore = metadata.primary_identifier.load(self._db)
+                oclc_editions = other_identifier.primarily_identifies
 
                 # Keep track of the number of editions OCLC associates
                 # with this identifier.
-                metadata.primary_identifier.add_measurement(
+                other_identifier.add_measurement(
                     self.output_source, Measurement.PUBLISHED_EDITIONS, 
                     len(oclc_editions)
                 )
+                
+                # If any contributors are identified solely by their
+                # VIAF IDs, look up those IDs and fill those in
+                # now. This will avoid problems later when it's time
+                # to turn these contributors into Contributor objects.
+                for i in metadata.contributors:
+                    if i.viaf and not i.sort_name:
+                        r = self.viaf.lookup_by_viaf(
+                            i.viaf, i.sort_name, i.display_name
+                        )
+                        i.viaf, i.display_name, i.family_name, i.sort_name, i.wikipedia_name = r
 
                 num_new_isbns = self.new_isbns(metadata)
                 if oclc_editions:
@@ -1312,7 +1326,7 @@ class LinkedDataCoverageProvider(CoverageProvider):
                 elif num_new_isbns:
                     edition, ignore = get_one_or_create(
                         self._db, Edition, data_source=self.output_source,
-                        primary_identifier=metadata.primary_identifier
+                        primary_identifier=other_identifier
                     )
                     metadata.apply(edition)
                     self.set_equivalence(identifier, metadata)
@@ -1333,7 +1347,10 @@ class LinkedDataCoverageProvider(CoverageProvider):
             else:
                 exception = "OCLC raised an error: %r" % e
                 transient = True
-            return CoverageFailure(identifier, exception, transient=transient)
+            return CoverageFailure(
+                identifier, exception, data_source=self.output_source,
+                transient=transient
+            )
         return identifier
 
     def new_isbns(self, metadata):

--- a/oclc.py
+++ b/oclc.py
@@ -540,7 +540,7 @@ class OCLCLinkedData(object):
 
         self.log.info("Processing edition %s: %r", oclc_id, titles)
         metadata = Metadata(self.source)
-        metadata.primary_identifier, new = IdentifierData(
+        metadata.primary_identifier = IdentifierData(
             type=oclc_id_type, identifier=oclc_id
         )
         if titles:

--- a/testing.py
+++ b/testing.py
@@ -1,0 +1,25 @@
+class MockOCLCLinkedDataAPI(object):
+
+    def __init__(self):
+        self.info_results = []
+
+    def queue_info_for(self, *metadatas):
+        self.info_results.append(metadatas)
+
+    def info_for(self, *args, **kwargs):
+        return self.info_results.pop(0)
+
+
+class MockVIAFClient(object):
+
+    def __init__(self):
+        self.results = []
+
+    def queue_lookup(self, *result):
+        self.results.append(result)
+
+    def lookup_by_viaf(self, *args, **kwargs):
+        return self.results.pop(0)
+    
+    def lookup_by_name(self, *args, **kwargs):
+        return self.results.pop(0)


### PR DESCRIPTION
Sometimes OCLC Linked Data identifies an author solely by VIAF and we can't write the data to the database because the metadata layer won't create a Contributor object with no sort_name. This leads to a lot of failures in the metadata wrangler's identifier resolution code. 

This is maybe not the right thing to do all the time, but it's very useful to guarantee that every person in the database has a name, so rather than remove this restriction I now avoid it by doing a quick VIAF lookup on the spot and filling in the rest of the information.

This branch also includes what I believe is the first end-to-end test of `LinkedDataCoverageProvider.process_item()`.