### PR TITLE
Always make sure to pass an Identifier object, not an IdentifierData, into Identifier.equivalent_to.

### DIFF
--- a/oclc.py
+++ b/oclc.py
@@ -1392,6 +1392,9 @@ class LinkedDataCoverageProvider(CoverageProvider):
             strength = 1
 
         if strength > 0:
+            primary_identifier, ignore = metadata.primary_identifier.load(
+                self._db
+            )
             identifier.equivalent_to(
-                self.output_source, metadata.primary_identifier, strength
+                self.output_source, primary_identifier, strength
             )


### PR DESCRIPTION
This branch fixes a problem where `IdentifierData` objects were being passed into data model methods that expected to take data model `Identifier` objects. It also corrects the test, which was sidestepping the problem by associating `Identifier` objects with `Metadata` objects where it should have been using `IdentifierData` objects.