### PR TITLE
Fix LinkedDataCoverageProvider error with VIAF

### DIFF
--- a/canonicalize.py
+++ b/canonicalize.py
@@ -102,11 +102,11 @@ class AuthorNameCanonicalizer(object):
         self.log.debug("Attempting to canonicalize %s", display_name)
         contributors = self._db.query(Contributor).filter(
             Contributor.display_name==display_name).filter(
-                Contributor.name != None).all()
+                Contributor.sort_name != None).all()
         sort_name = None
         if contributors and False:
             # Yes, awesome. Use this name.
-            sort_name = contributors[0].name
+            sort_name = contributors[0].sort_name
             self.log.debug(
                 "Found existing contributor for %s: %s",
                 display_name, sort_name

--- a/canonicalize.py
+++ b/canonicalize.py
@@ -1,18 +1,21 @@
 """Use external services to canonicalize names."""
-from nose.tools import set_trace
 import logging
-from oclc import OCLCLinkedData
+import re
+from nose.tools import set_trace
+
+from core.model import (
+    Contributor,
+    Identifier,
+)
 from core.util import MetadataSimilarity
 from core.util.personal_names import (
     display_name_to_sort_name,
     is_corporate_name,
 )
+
+from oclc import OCLCLinkedData
 from viaf import VIAFClient
-from core.model import (
-    Contributor,
-    Identifier,
-)
-import re
+
 
 class CanonicalizationError(Exception):
     pass
@@ -53,7 +56,7 @@ class AuthorNameCanonicalizer(object):
 
         return author_name
 
-    def canonicalize(self, identifier, display_name):
+    def canonicalize_author_name(self, identifier, display_name):
         """Canonicalize a book's primary author given an identifier and a
         display name.
 
@@ -71,7 +74,8 @@ class AuthorNameCanonicalizer(object):
             identifier = None
         if not identifier and not display_name:
             raise CanonicalizationError(
-                "Neither useful identifier nor display name was provided.")
+                "Neither useful identifier nor display name was provided."
+            )
 
         # From an author name that potentially names multiple people,
         # extract only the first name.
@@ -84,8 +88,9 @@ class AuthorNameCanonicalizer(object):
             if v:
                 return v
 
-        # All our techniques have failed. Woe!
-        return None
+        # All our techniques have failed. Woe! Let's just try to finagle
+        # this provided display name into a sort name.
+        return self.default_name(display_name)
 
     def default_name(self, display_name):
         shortened_name = self.primary_author_name(display_name)

--- a/canonicalize.py
+++ b/canonicalize.py
@@ -125,10 +125,10 @@ class AuthorNameCanonicalizer(object):
                 m = self.VIAF_ID.search(uri)
                 if m:
                     viaf_id = m.groups()[0]
-                    viaf_id, display_name, family_name, sort_name, wikipedia_name = (
-                        self.viaf.lookup_by_viaf(
-                            viaf_id, working_display_name=display_name))
-                    if sort_name:
+                    contributor_data = self.viaf.lookup_by_viaf(
+                        viaf_id, working_display_name=display_name
+                    )[0]
+                    if contributor_data.sort_name:
                         return sort_name
 
         # Nope. If we were given a display name, let's ask VIAF about it
@@ -191,9 +191,16 @@ class AuthorNameCanonicalizer(object):
         return shortest_candidate, uris
 
     def sort_name_from_viaf(self, display_name):
-        viaf, display_name, family_name, sort_name, wikipedia_name = (
-                self.viaf.lookup_by_name(None, display_name))
-        self.log.debug("Asked VIAF for sort name for %s. Response: %s",
-                       display_name, sort_name)
-        return sort_name
+        sort_name = None
 
+        viaf_contributor = self.viaf.lookup_by_name(
+            None, display_name, best_match=True
+        )
+        if viaf_contributor:
+            contributor_data = viaf_contributor[0]
+            sort_name = contributor_data.sort_name
+            self.log.debug(
+                "Asked VIAF for sort name for %s. Response: %s",
+                display_name, sort_name
+            )
+        return sort_name

--- a/gutenberg.py
+++ b/gutenberg.py
@@ -51,7 +51,7 @@ class OCLCClassifyCoverageProvider(CoverageProvider):
         if len(authors) == 0:
             author = ''
         else:
-            author = authors[0].name
+            author = authors[0].sort_name
 
         language = edition.language
 
@@ -127,10 +127,10 @@ class OCLCClassifyCoverageProvider(CoverageProvider):
         gutenberg_authors_to_merge = [
             x for x in edition.author_contributors if not x.viaf or not x.lc
         ]
-        gutenberg_names = set([x.name for x in edition.author_contributors])
+        gutenberg_names = set([x.sort_name for x in edition.author_contributors])
         for r in records:
             if gutenberg_authors_to_merge:
-                oclc_names = set([x.name for x in r.author_contributors])
+                oclc_names = set([x.sort_name for x in r.author_contributors])
                 if gutenberg_names == oclc_names:
                     # Perfect overlap. We've found an OCLC record
                     # for a book written by exactly the same
@@ -138,7 +138,7 @@ class OCLCClassifyCoverageProvider(CoverageProvider):
                     # Gutenberg author into its OCLC equivalent.
                     for gutenberg_author in gutenberg_authors_to_merge:
                         oclc_authors = [x for x in r.author_contributors
-                                        if x.name == gutenberg_author.name]
+                                        if x.sort_name == gutenberg_author.sort_name]
                         if len(oclc_authors) == 1:
                             oclc_author = oclc_authors[0]
                             if oclc_author != gutenberg_author:

--- a/oclc.py
+++ b/oclc.py
@@ -832,7 +832,7 @@ class OCLCXMLParser(XMLParser):
     @classmethod
     def _contributor_match(cls, contributor, name, lc, viaf):
         return (
-            contributor.name == name
+            contributor.sort_name == name
             and (lc is None or contributor.lc == lc)
             and (viaf is None or contributor.viaf == viaf)
         )
@@ -880,7 +880,7 @@ class OCLCXMLParser(XMLParser):
             # No name was given for the author.
             return None, roles, default_role_used
 
-        if primary_author and author == primary_author.name:
+        if primary_author and author == primary_author.sort_name:
             if Contributor.AUTHOR_ROLE in roles:
                 roles.remove(Contributor.AUTHOR_ROLE)
             if Contributor.UNKNOWN_ROLE in roles:
@@ -1032,7 +1032,7 @@ class OCLCXMLParser(XMLParser):
         if 'authors' in restrictions:
             restrict_to_authors = restrictions['authors']
             if restrict_to_authors and isinstance(restrict_to_authors[0], Contributor):
-                restrict_to_authors = [x.name for x in restrict_to_authors]
+                restrict_to_authors = [x.sort_name for x in restrict_to_authors]
             primary_author = None
 
             for a, roles in authors_and_roles:
@@ -1041,7 +1041,7 @@ class OCLCXMLParser(XMLParser):
                     break
             if (not primary_author
                 or (primary_author not in restrict_to_authors
-                    and primary_author.name not in restrict_to_authors)):
+                    and primary_author.sort_name not in restrict_to_authors)):
                     # None of the given authors showed up as the
                     # primary author of this book. They may have had
                     # some other role in it, or the book may be about
@@ -1049,7 +1049,7 @@ class OCLCXMLParser(XMLParser):
                     # is not *by* them.
                 return None
 
-        author_names = ", ".join([x.name for x, y in authors_and_roles])
+        author_names = ", ".join([x.sort_name for x, y in authors_and_roles])
 
         return title, authors_and_roles, language
 

--- a/scripts.py
+++ b/scripts.py
@@ -105,7 +105,7 @@ class PermanentWorkIDStressTestGenerationScript(Script):
         contributors = edition.author_contributors
         if contributors:
             primary_author = contributors[0]
-            primary_author_name = primary_author.name
+            primary_author_name = primary_author.sort_name
         else:
             primary_author_name = None
         author = WorkIDCalculator.normalize_author(primary_author_name)

--- a/testing.py
+++ b/testing.py
@@ -1,3 +1,5 @@
+from nose.tools import set_trace
+
 class MockOCLCLinkedDataAPI(object):
 
     def __init__(self):
@@ -15,8 +17,8 @@ class MockVIAFClient(object):
     def __init__(self):
         self.results = []
 
-    def queue_lookup(self, *result):
-        self.results.append(result)
+    def queue_lookup(self, *results):
+        self.results += results
 
     def lookup_by_viaf(self, *args, **kwargs):
         return self.results.pop(0)

--- a/tests/test_oclc.py
+++ b/tests/test_oclc.py
@@ -577,10 +577,7 @@ class TestLinkedDataCoverageProvider(DatabaseTest):
         lookup2 = (ContributorData(
                    viaf="2", wikipedia_name="Robert_Jordan_(Author)",
                    biography="That guy."), None, None)
-        # Metadata.apply also looks up the contributor in VIAF, in an attempt
-        # to find the sort name. So we'll have to queue these up twice
-        # or our data will be overwritten later, thereby ruining the test.
-        viaf.queue_lookup(lookup1, lookup2, lookup1, lookup2)
+        viaf.queue_lookup(lookup1, lookup2)
 
         provider.process_item(identifier)
 

--- a/tests/test_oclc.py
+++ b/tests/test_oclc.py
@@ -107,14 +107,14 @@ class TestParser(DatabaseTest):
         """We can choose to only accept works by a given author."""
         xml = self.sample_data("multi_work_response.xml")
 
-        [wrong_author], ignore = Contributor.lookup(self._db, name="Wrong Author")
+        [wrong_author], ignore = Contributor.lookup(self._db, sort_name="Wrong Author")
         status, swids = OCLCXMLParser.parse(
             self._db, xml, languages=["eng"], authors=[wrong_author])
         # This person is not listed as an author of any work in the dataset,
         # so none of those works were picked up.
         eq_(0, len(swids))
 
-        [melville], ignore = Contributor.lookup(self._db, name="Melville, Herman")
+        [melville], ignore = Contributor.lookup(self._db, sort_name="Melville, Herman")
         status, swids = OCLCXMLParser.parse(
             self._db, xml, languages=["eng"], authors=[melville])
 
@@ -132,7 +132,7 @@ class TestParser(DatabaseTest):
 
     def test_primary_author_name(self):
         melville = OCLCXMLParser.primary_author_from_author_string(self._db, "Melville, Herman, 1819-1891 | Hayford, Harrison [Associated name; Editor] | Parker, Hershel [Editor] | Tanner, Tony [Editor; Commentator for written text; Author of introduction; Author] | Cliffs Notes, Inc. | Kent, Rockwell, 1882-1971 [Illustrator]")
-        eq_("Melville, Herman", melville.name)
+        eq_("Melville, Herman", melville.sort_name)
 
         eq_(None, OCLCXMLParser.primary_author_from_author_string(
             self._db,
@@ -160,7 +160,7 @@ class TestParser(DatabaseTest):
 
         eq_("Moby Dick", work.title)
 
-        work_contributors = [x.name for x in work.contributors]
+        work_contributors = [x.sort_name for x in work.contributors]
 
         # The work has a ton of contributors, collated from all the
         # editions.
@@ -188,10 +188,10 @@ class TestParser(DatabaseTest):
         # OCLC. Herman Melville is the primary author, and Tony Tanner is
         # also credited as an author.
         primary_author = sorted(
-            [x.contributor.name for x in work.contributions
+            [x.contributor.sort_name for x in work.contributions
              if x.role==Contributor.PRIMARY_AUTHOR_ROLE])[0]
         other_author = sorted(
-            [x.contributor.name for x in work.contributions
+            [x.contributor.sort_name for x in work.contributions
              if x.role==Contributor.AUTHOR_ROLE])[0]
 
         eq_("Melville, Herman", primary_author)
@@ -257,7 +257,7 @@ class TestAuthorParser(DatabaseTest):
     def assert_author(self, result, name, role=Contributor.AUTHOR_ROLE,
                       birthdate=None, deathdate=None):
         contributor, roles = result
-        eq_(contributor.name, name)
+        eq_(contributor.sort_name, name)
         if role:
             if not isinstance(role, list) and not isinstance(role, tuple):
                 role = [role]
@@ -584,7 +584,7 @@ class TestLinkedDataCoverageProvider(DatabaseTest):
         # Both authors have had their information updated with the
         # VIAF results.
         filled_in = sorted(
-            [(x.name, x.display_name, x.viaf, x.wikipedia_name, x.biography)
+            [(x.sort_name, x.display_name, x.viaf, x.wikipedia_name, x.biography)
              for x in edition.contributors]
         )
         eq_(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -118,5 +118,5 @@ class TestRedoOCLCForThreeM(DatabaseTest):
         eq_(1, len(self.edition1.contributors))
         eq_(
             ["Denzel Washington"], 
-            [x.name for x in self.edition1.contributors]
+            [x.sort_name for x in self.edition1.contributors]
         )

--- a/tests/test_viaf.py
+++ b/tests/test_viaf.py
@@ -8,10 +8,6 @@ from . import (
     sample_data,
 )
 
-from core.model import (
-    Contributor,
-)
-
 from viaf import (
     VIAFParser, 
     VIAFClient

--- a/tests/test_viaf.py
+++ b/tests/test_viaf.py
@@ -238,11 +238,8 @@ class TestVIAFClient(DatabaseTest):
         xml = self.sample_data("mindy_kaling.xml")
         h.queue_response(200, media_type='text/xml', content=xml)
 
-        [(selected_candidate, match_confidences, contributor_titles)] = self.client.lookup_by_name(sort_name="Mindy Kaling", do_get=h.do_get)
+        (selected_candidate,
+         match_confidences,
+         contributor_titles) = self.client.lookup_by_name(sort_name="Mindy Kaling", do_get=h.do_get)
         eq_(selected_candidate.viaf, "9581122")
         eq_(selected_candidate.sort_name, "Kaling, Mindy")
-
-
-
-
-

--- a/viaf.py
+++ b/viaf.py
@@ -136,7 +136,7 @@ class VIAFParser(XMLParser):
         # the given author, make sure that one of the working names
         # shows up in a name record.
         if strict:
-            if len(match_confidences) == 0:
+            if not match_confidences:
                 return 0
 
         # Assign weights to fields matched in the xml.  
@@ -369,8 +369,7 @@ class VIAFParser(XMLParser):
         :return: the list of tuples, ordered by percent match, in descending order 
         (top match first).
         """
-
-        if len(contributor_candidates) == 0:
+        if not contributor_candidates:
             return contributor_candidates
 
         # if the top library popularity candidate is a really bad name match, 
@@ -380,8 +379,8 @@ class VIAFParser(XMLParser):
 
         # double-check that the candidate list is ordered by library popularity, as it came from viaf
         if match_confidences["library_popularity"] == 1:
-            # baaad match
             if (("sort_name" in match_confidences) and (match_confidences["sort_name"] < 50)) or ("sort_name" not in match_confidences):
+                # baaad match
                 ignore_popularity = True
 
             if "sort_name" not in match_confidences:
@@ -459,7 +458,8 @@ class VIAFParser(XMLParser):
 
         tree = etree.fromstring(xml, parser=etree.XMLParser(recover=True))
         return self.extract_viaf_info(
-            tree, working_sort_name, working_display_name)
+            tree, working_sort_name, working_display_name
+        )
 
 
     def extract_wikipedia_name(self, cluster):
@@ -498,7 +498,9 @@ class VIAFParser(XMLParser):
 
         # Find out if one of the working names shows up in a name record.
         match_confidences = self.cluster_has_record_for_named_author(
-                cluster, working_sort_name, working_display_name, contributor_data)        
+                cluster, working_sort_name, working_display_name,
+                contributor_data
+        )
 
         # Get the VIAF ID for this cluster, just in case we don't have one yet.
         viaf_tag = self._xpath1(cluster, './/*[local-name()="viafID"]')
@@ -699,23 +701,18 @@ class VIAFClient(object):
         from VIAF or None on error.
         """
         if contributor.viaf:
-            # We can look them up by VIAF.
-            contributor_candidates = self.lookup_by_viaf(
-                contributor.viaf, contributor.name, contributor.display_name)
+            contributor_candidate = self.lookup_by_viaf(
+                contributor.viaf, contributor.name, contributor.display_name
+            )
         else:
-            contributor_candidates = self.lookup_by_name(contributor.name, contributor.display_name)
-
-        # we have the viaf results for all clusters corresponding to 
-        # this contributor.  now sort them to get the best match.
-        if contributor_candidates:
-            contributor_candidates = self.parser.order_candidates(working_sort_name=contributor.name, contributor_candidates=contributor_candidates)
-            (selected_candidate, match_confidences, contributor_titles)  = contributor_candidates[0]
-
-        # having a cluster of authors doesn't mean we found a match.  
-        if not selected_candidate or "total" not in match_confidences or match_confidences["total"] < 70:
-            # no match or bad match.  give up.
+            contributor_candidate = self.lookup_by_name(
+                contributor.name, contributor.display_name
+            )
+        if not contributor_candidate:
+            # No good match was identified.
             return None
 
+        (selected_candidate, match_confidences, contributor_titles) = best_contributor_candidate
         # Is there already another contributor with this VIAF?
         if selected_candidate.viaf is not None:
             duplicates = self._db.query(Contributor).filter(
@@ -742,6 +739,29 @@ class VIAFClient(object):
 
         return selected_candidate
 
+    def select_best_match(self, candidates, working_sort_name):
+        """Gets the best VIAF match from a series of potential matches
+
+        Return a tuple containing the selected_candidate (a ContributorData
+        object), a dict of match_confidences, and a list of titles by the
+        contributor.
+        """
+        # Sort for the best match and select the first.
+        candidates = self.parser.order_candidates(
+            working_sort_name=working_sort_name,
+            contributor_candidates=candidates
+        )
+        if not candidates:
+            return None
+
+        (selected_candidate, match_confidences, contributor_titles) = candidates[0]
+
+        if (not selected_candidate or "total" not in match_confidences or
+            match_confidences["total"] < 70):
+            # The best match is dubious. Best to avoid this.
+            return None
+
+        return selected_candidate, match_confidences, contributor_titles
 
     def lookup_by_viaf(self, viaf, working_sort_name=None,
                        working_display_name=None, do_get=None):
@@ -751,39 +771,42 @@ class VIAFClient(object):
         xml = r.content
         return self.parser.parse(xml, working_sort_name, working_display_name)
 
-
-    def lookup_by_name(self, sort_name, display_name=None, do_get=None):
-        name = sort_name or display_name
-        # from OCLC tech support:  
-        # VIAF's SRU endpoint can only return a maximum number of 10 records when the recordSchema is http://viaf.org/VIAFCluster
+    def lookup_by_name(self, sort_name, display_name=None, do_get=None,
+                       best_match=False):
+        sort_name = sort_name or display_name
+        # from OCLC tech support:
+        # VIAF's SRU endpoint can only return a maximum number of 10 records
+        # when the recordSchema is http://viaf.org/VIAFCluster
         maximum_records = 10 # viaf maximum that's not ignored
         page = 1
         contributor_candidates = []
 
-        # limit ourselves to reading the first 500 viaf clusters, on the assumption that 
-        # search match quality is unlikely to be usable after that.
-        #for page in range (20, 22):
+        # limit ourselves to reading the first 500 viaf clusters, on the
+        # assumption that search match quality is unlikely to be usable after that.
         for page in range (1, 51):
             start_record = 1 + maximum_records * (page-1)
             scope = 'local.personalNames'
             if is_corporate_name(sort_name):
                 scope = 'local.corporateNames'
 
-            url = self.SEARCH_URL.format(scope=scope, sort_name=name.encode("utf8"), maximum_records=maximum_records, start_record=start_record)
+            url = self.SEARCH_URL.format(
+                scope=scope, sort_name=sort_name.encode("utf8"),
+                maximum_records=maximum_records, start_record=start_record
+            )
             representation, cached = Representation.get(self._db, url, do_get=do_get)
             xml = representation.content
 
             candidates = self.parser.parse_multiple(xml, sort_name, display_name, page)
             if not any(candidates):
                 # Delete the representation so it's not cached.
-                self._db.query(Representation).filter(Representation.id==representation.id).delete()
-                # we ran out of clusters, so we can relax and move on to ordering the returned results
+                self._db.query(Representation).filter(
+                    Representation.id==representation.id
+                ).delete()
+                # We ran out of clusters, so we can relax and move on to
+                # ordering the returned results
                 break
 
             contributor_candidates.extend(candidates)
             page += 1
 
-        return contributor_candidates
-
-
-
+        return self.select_best_match(contributor_candidates, sort_name)

--- a/viaf.py
+++ b/viaf.py
@@ -707,11 +707,11 @@ class VIAFClient(object):
         """
         if contributor.viaf:
             contributor_candidate = self.lookup_by_viaf(
-                contributor.viaf, contributor.name, contributor.display_name
+                contributor.viaf, contributor.sort_name, contributor.display_name
             )
         else:
             contributor_candidate = self.lookup_by_name(
-                contributor.name, contributor.display_name
+                contributor.sort_name, contributor.display_name
             )
         if not contributor_candidate:
             # No good match was identified.


### PR DESCRIPTION
The main changes here were:
 1. Changing both VIAF and the LInkedDataCoverageProvider to ensure the `VIAFClient#lookup_by_viaf` response returns what's expected. Adjusted the provider's tests accordingly, too.
 2. `VIAFClient#lookup_by_name` now returns a single best candidate instead of a list, which allowed me to fix a couple broken references to that method as well.
 3. Refactoring the Canonicalizer so it could be passed into `Metadata#apply`. It's also now in a Controller and out of app.py, which feels like a win-win. 😄 

Musings:
- As you can see in the test, VIAF is now being hit _twice_ for each candidate found during the OCLC LinkedData coverage process. And -- since VIAF isn't holding on to Representations -- it is actually making the API call both times. This is going to extend the time needed to run the provider. 
- I had a thought to create a VIAFCandidate object (or something like it) instead of passing around a tuple with extraneous bits, but I didn't think it was worth the time or effort at this point.

Fixes #87.