### PR TITLE
Fix Identifier Resolution utility command

### DIFF
--- a/bin/identifiers_resolve
+++ b/bin/identifiers_resolve
@@ -5,5 +5,8 @@ import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
-from scripts import RunIdentifierResolutionMonitor
-RunIdentifierResolutionMonitor().run()
+
+from core.scripts import RunCoverageProviderScript
+
+from coverage import IdentifierResolutionCoverageProvider
+RunCoverageProviderScript(IdentifierResolutionCoverageProvider).run()

--- a/coverage.py
+++ b/coverage.py
@@ -64,7 +64,7 @@ class IdentifierResolutionCoverageProvider(CoverageProvider):
     UNKNOWN_FAILURE = "Unknown failure."
 
     def __init__(self, _db, batch_size=10, cutoff_time=None,
-                 uploader=None, providers=None):
+                 uploader=None, providers=None, **kwargs):
         output_source, made_new = get_one_or_create(
             _db, DataSource,
             name=DataSource.INTERNAL_PROCESSING, offers_licenses=False,


### PR DESCRIPTION
The script in `/bin` was broken after we changed the IdentifierResolutionMonitor to an IdentifierResolutionCoverageProvider. No longer.