### PR TITLE
Give ISBNs license pools

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,6 @@ from core.util.problem_detail import ProblemDetail
 from core.opds import VerboseAnnotator
 from core.app_server import (
     HeartbeatController,
-    URNLookupController,
     returns_problem_detail,
 )
 from core.model import production_session
@@ -19,7 +18,8 @@ from core.config import Configuration
 
 from controller import (
     CollectionController,
-    CanonicalizationController
+    CanonicalizationController,
+    URNLookupController
 )
 
 

--- a/app.py
+++ b/app.py
@@ -14,10 +14,7 @@ from core.app_server import (
     URNLookupController,
     returns_problem_detail,
 )
-from core.model import (
-    production_session,
-    Identifier,
-)
+from core.model import production_session
 from core.config import Configuration
 
 from controller import (

--- a/controller.py
+++ b/controller.py
@@ -238,7 +238,7 @@ class URNLookupController(CoreURNLookupController):
         # this Identifier part of the given collection.
         if collection:
             collection.catalog_identifier(self._db, identifier)
-        
+
         if identifier.type == Identifier.ISBN:
             # ISBNs are handled specially.
             return self.make_opds_entry_from_metadata_lookups(identifier)
@@ -315,7 +315,7 @@ class URNLookupController(CoreURNLookupController):
                 [x.id for x in metadata_sources]
             )
         )
-        
+
         coverage_records = q.all()
         unaccounted_for = set(metadata_sources)
         for r in coverage_records:

--- a/coverage.py
+++ b/coverage.py
@@ -172,7 +172,8 @@ class IdentifierResolutionCoverageProvider(CoverageProvider):
                 return self.transform_exception_into_failure(e, identifier)
 
         try:
-            self.finalize(identifier)
+            self.resolve_equivalent_oclc_identifiers(identifier)
+            self.process_work(identifier)
         except Exception as e:
             return self.transform_exception_into_failure(e, identifier)
 

--- a/coverage.py
+++ b/coverage.py
@@ -172,8 +172,7 @@ class IdentifierResolutionCoverageProvider(CoverageProvider):
                 return self.transform_exception_into_failure(e, identifier)
 
         try:
-            self.resolve_equivalent_oclc_identifiers(identifier)
-            self.process_work(identifier)
+            self.finalize(identifier)
         except Exception as e:
             return self.transform_exception_into_failure(e, identifier)
 

--- a/migration/20160913-2-change-all-license-pools-sources-to-internal-processing.sql
+++ b/migration/20160913-2-change-all-license-pools-sources-to-internal-processing.sql
@@ -1,0 +1,3 @@
+UPDATE licensepools SET data_source_id = (
+    SELECT id FROM datasources WHERE name = 'Library Simplified Internal Process'
+) WHERE id IS NOT NULL;

--- a/migration/20160913-3-remove-unresolved-3m-identifiers-from-queue.sql
+++ b/migration/20160913-3-remove-unresolved-3m-identifiers-from-queue.sql
@@ -1,0 +1,5 @@
+delete from coveragerecords
+    where operation = 'resolve-identifier' and
+    identifier_id in (
+        select id from identifiers where type in ('3M ID', 'Bibliotheca ID')
+    );

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -189,7 +189,6 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
         eq_(True, isinstance(result, CoverageFailure))
         eq_(True, result.transient)
 
-
     def test_process_item_fails_when_required_provider_raises_exception(self):
         self.coverage_provider.required_coverage_providers = [self.broken]
         result = self.coverage_provider.process_item(self.identifier)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -222,10 +222,15 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
 
         result = self.coverage_provider.process_item(self.identifier)
 
-        # A successful result is achieved.
+        # A successful result is achieved, even though the optional
+        # coverage provider failed.
         eq_(result, self.identifier)
-        # Even though the coverage provider failed and an appropriate
-        # coverage record was created to mark the failure.
-        r = get_one(self._db, CoverageRecord, identifier=self.identifier)
-        eq_("What did you expect?", r.exception)
 
+        # An appropriate coverage record was created to mark the failure.
+        presentation_edition = DataSource.lookup(
+            self._db, DataSource.PRESENTATION_EDITION
+        )
+        r = self._db.query(CoverageRecord).filter(
+            CoverageRecord.identifier==self.identifier,
+            CoverageRecord.data_source!=presentation_edition).one()
+        eq_("What did you expect?", r.exception)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -11,6 +11,7 @@ from core.model import (
     DataSource,
     get_one, 
     Identifier,
+    LicensePool,
 )
 from core.coverage import CoverageFailure
 from core.opds_import import MockSimplifiedOPDSLookup
@@ -146,7 +147,19 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
         self.never_successful = NeverSuccessfulCoverageProvider(
             "Never", [self.identifier.type], self.source
         )
-        self.broken = BrokenCoverageProvider("Broken", [self.identifier.type], self.source)
+        self.broken = BrokenCoverageProvider(
+            "Broken", [self.identifier.type], self.source
+        )
+
+    def test_process_item_creates_license_pool(self):
+        self.coverage_provider.required_coverage_providers = [
+            self.always_successful
+        ]
+
+        self.coverage_provider.process_item(self.identifier)
+        lp = self.identifier.licensed_through
+        eq_(True, isinstance(lp, LicensePool))
+        eq_(lp.data_source, self.coverage_provider.output_source)
 
     def test_process_item_succeeds_if_all_required_coverage_providers_succeed(self):
         self.coverage_provider.required_coverage_providers = [


### PR DESCRIPTION
This branch:
- Stops using the core URNLookupController (😦 )
- Gives all identifiers "fake" internal license pools, intended entirely for processing purposes.
- Allows DataSource.INTERNAL_PROCESSING to offer licenses for just such purposes.
- Adjusts tests accordingly.
- Removes all 3M/Bibliotheca identifiers from the identifier resolution queue.