### PR TITLE
Remove Bibliotheca/3M OCLC Classify coverage failures

### DIFF
--- a/migration/20160921-remove-threem-oclc-classify-failures.sql
+++ b/migration/20160921-remove-threem-oclc-classify-failures.sql
@@ -1,0 +1,9 @@
+delete from coveragerecords where id in (
+    select cr.id from coveragerecords cr
+    join datasources d on cr.data_source_id = d.id
+    join identifiers i on cr.identifier_id = i.id
+    where
+        d.name = 'OCLC Classify' and
+        i.type in ('Bibliotheca ID', '3M ID') and
+        cr.status = 'transient failure'
+);    


### PR DESCRIPTION
3M Identifiers are no longer getting coverage from the OCLC Classify. This migration will remove any transient failure coverage records from the database.