### PR TITLE
Fix resolved identifier migration

### DIFF
--- a/migration/20161007-cover-resolved-identifiers.py
+++ b/migration/20161007-cover-resolved-identifiers.py
@@ -11,6 +11,7 @@ sys.path.append(os.path.abspath(package_dir))
 
 from nose.tools import set_trace
 from sqlalchemy import or_
+from sqlalchemy.orm import lazyload
 
 from core.model import (
     get_one_or_create,
@@ -32,9 +33,10 @@ resolved_identifiers = _db.query(Identifier).\
     filter(Identifier.type.in_([Identifier.ISBN, Identifier.OVERDRIVE_ID])).\
     outerjoin(Identifier.coverage_records).\
     outerjoin(CoverageRecord.data_source).\
-    filter(or_(DataSource.name==None, DataSource.name!=source.name)).\
+    filter(or_(CoverageRecord.id==None, DataSource.name!=source.name)).\
     outerjoin(Identifier.unresolved_identifier).\
-    filter(CoverageRecord.id==None, UnresolvedIdentifier.id==None).all()
+    filter(UnresolvedIdentifier.id==None).\
+    options(lazyload(Identifier.licensed_through)).all()
 
 print "Resolving %d Identifiers with CoverageRecords" % len(resolved_identifiers)
 


### PR DESCRIPTION
So the last time I ran this, it was eagerloading LicensePools and DataSources and it was only looking for identifiers that had NO coverage records and no UnresolvedIdentifier. This overlooked a large number of identifiers that had received coverage long when the Identifier Resolution process was a Monitor..

Now this migration actually captures the missing identifiers and creates coverage records for them.

This was the old SQL query:
```
SELECT
    identifiers.id,
    identifiers.type
    identifiers.identifier
    licensepools_1.id
    licensepools_1.work_id
    licensepools_1.data_source_id
    licensepools_1.identifier_id
    licensepools_1.presentation_edition_id
    licensepools_1.availability_time
    licensepools_1.superceded
    licensepools_1.suppressed
    licensepools_1.license_exception
    licensepools_1.open_access
    licensepools_1.last_checked
    licensepools_1.licenses_owned
    licensepools_1.licenses_available
    licensepools_1.licenses_reserved
    licensepools_1.patrons_in_hold_queue
    datasources_1.id
    datasources_1.name
    datasources_1.offers_licenses
    datasources_1.primary_identifier_type
    datasources_1.extra
FROM identifiers
LEFT OUTER JOIN coveragerecords ON identifiers.id = coveragerecords.identifier_id
LEFT OUTER JOIN datasources ON datasources.id = coveragerecords.data_source_id
LEFT OUTER JOIN unresolvedidentifiers ON identifiers.id = unresolvedidentifiers.identifier_id
LEFT OUTER JOIN licensepools AS licensepools_1 ON identifiers.id = licensepools_1.identifier_id
LEFT OUTER JOIN datasources AS datasources_1 ON datasources_1.id = licensepools_1.data_source_id
WHERE
    identifiers.type IN ('ISBN', 'Overdrive ID') AND
    (datasources.name IS NULL OR datasources.name != 'Library Simplified Internal Process') AND
    coveragerecords.id IS NULL AND
    unresolvedidentifiers.id IS NULL
```

This is the new and improved version:
```
SELECT identifiers.id, identifiers.type, identifiers.identifier FROM identifiers
LEFT OUTER JOIN unresolvedidentifiers ON identifiers.id = unresolvedidentifiers.identifier_id
WHERE
    identifiers.type in ('ISBN', 'Overdrive ID') AND
    unresolvedidentifiers.id IS NULL AND
    NOT (EXISTS (
        SELECT 1 FROM coveragerecords
        WHERE
            identifiers.id = coveragerecords.identifier_id AND
            coveragerecords.id IN (SELECT coveragerecords.id
                FROM coveragerecords JOIN datasources ON datasources.id = coveragerecords.data_source_id
                WHERE datasources.name = 'Library Simplified Internal Process')
    ));
```