### PR TITLE
Avoid resolving equivalent identifiers

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -124,6 +124,20 @@ class IdentifierResolutionCoverageProvider(CoverageProvider):
         )
         self.oclc_linked_data = LinkedDataCoverageProvider(self._db)
 
+    def items_that_need_coverage(self, identifiers=None, **kwargs):
+        """Find all identifiers lacking coverage from this CoverageProvider.
+
+        Only identifiers that have been requested via the URNLookupController
+        (and thus given 'transient failure' CoverageRecords) should be
+        returned. Identifiers created through previous resolution processes
+        can be ignored.
+        """
+        qu = super(IdentifierResolutionCoverageProvider, self).items_that_need_coverage(
+            identifiers=identifiers, **kwargs
+        )
+        qu = qu.filter(CoverageRecord.id != None)
+        return qu
+
     def process_item(self, identifier):
         """For this identifier, checks that it has all of the available
         3rd party metadata, and if not, obtains it.

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -151,6 +151,19 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
             "Broken", [self.identifier.type], self.source
         )
 
+    def test_items_that_need_coverage(self):
+        # Only items with an existing transient failure status require coverage.
+        self._coverage_record(
+            self.identifier, self.coverage_provider.output_source,
+            operation=CoverageRecord.RESOLVE_IDENTIFIER_OPERATION,
+            status=CoverageRecord.TRANSIENT_FAILURE
+        )
+        # Identifiers without coverage will be ignored.
+        no_coverage = self._identifier(identifier_type=Identifier.ISBN)
+
+        items = self.coverage_provider.items_that_need_coverage().all()
+        eq_([self.identifier], items)
+
     def test_process_item_creates_license_pool(self):
         self.coverage_provider.required_coverage_providers = [
             self.always_successful


### PR DESCRIPTION
Only identifiers that have been requested by a Circulation Manager (and thus provided with a 'transient failure' CoverageRecord) should be sought out for coverage by the IdentifierResolutionCoverageProvider.

In this case, when identifiers that don't have a CoverageRecord at all are considered "uncovered", the equivalent ISBNs created through the resolution process are then added to the work that needs to be done, creating editions that no Circulation Manager needs and often fetching the same information that has already been discovered.