### PR TITLE
Rename Collection to Catalog

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ from core.model import production_session
 from core.config import Configuration
 
 from controller import (
-    CollectionController,
+    CatalogController,
     CanonicalizationController,
     URNLookupController
 )
@@ -45,23 +45,23 @@ else:
     Conf.initialize(_db)
 
 
-def accepts_collection(f):
+def accepts_catalog(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        collection = CollectionController(Conf.db).authenticated_collection_from_request(
+        catalog = CatalogController(Conf.db).authenticated_catalog_from_request(
             required=False
         )
-        if isinstance(collection, ProblemDetail):
-            return collection.response
-        return f(collection=collection, *args, **kwargs)
+        if isinstance(catalog, ProblemDetail):
+            return catalog.response
+        return f(catalog=catalog, *args, **kwargs)
     return decorated
 
 def requires_auth(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        collection = CollectionController(Conf.db).authenticated_collection_from_request()
-        if isinstance(collection, ProblemDetail):
-            return collection.response
+        catalog = CatalogController(Conf.db).authenticated_catalog_from_request()
+        if isinstance(catalog, ProblemDetail):
+            return catalog.response
         return f(*args, **kwargs)
     return decorated
 
@@ -79,11 +79,11 @@ def heartbeat():
     return HeartbeatController().heartbeat()
 
 @app.route('/lookup')
-@accepts_collection
-def lookup(collection=None):
+@accepts_catalog
+def lookup(catalog=None):
     return URNLookupController(Conf.db).work_lookup(
         VerboseAnnotator, require_active_licensepool=False,
-        collection=collection
+        catalog=catalog
     )
 
 @app.route('/canonical-author-name')
@@ -94,12 +94,12 @@ def canonical_author_name():
 @app.route('/updates')
 @requires_auth
 def updates():
-    return CollectionController(Conf.db).updates_feed()
+    return CatalogController(Conf.db).updates_feed()
 
 @app.route('/remove', methods=['POST'])
 @requires_auth
 def remove():
-    return CollectionController(Conf.db).remove_items()
+    return CatalogController(Conf.db).remove_items()
 
 if __name__ == '__main__':
 

--- a/bin/util/generate_catalog
+++ b/bin/util/generate_catalog
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
-"""Creates a new Collection with a provided name
+"""Creates a new Catalog with a provided name
 
 Utilize this script with the following format:
-bin/util/generate_collection The New York Public Library
+bin/util/generate_catalog The New York Public Library
 """
 import os
 import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
-from scripts import CollectionGeneratorScript
+from scripts import CatalogGeneratorScript
 
-CollectionGeneratorScript().run(sys.argv[1:])
+CatalogGeneratorScript().run(sys.argv[1:])

--- a/controller.py
+++ b/controller.py
@@ -155,7 +155,7 @@ class CatalogController(object):
                     )
                 else:
                     message = OPDSMessage(
-                        urn, HTTP_NOT_FOUND, "Not in catalog catalog"
+                        urn, HTTP_NOT_FOUND, "Not in catalog"
                     )
             if message:
                 messages.append(message)

--- a/scripts.py
+++ b/scripts.py
@@ -2,7 +2,7 @@ import csv
 import sys
 from nose.tools import set_trace
 from core.model import (
-    Collection,
+    Catalog,
     Contribution,
     DataSource,
     Edition,
@@ -118,7 +118,7 @@ class PermanentWorkIDStressTestGenerationScript(Script):
                        "ebook")
 
 
-class CollectionCategorizationOverviewScript(Script):
+class CatalogCategorizationOverviewScript(Script):
 
     def __init__(self, output_path=None, cutoff=0):
         self.cutoff=cutoff
@@ -312,20 +312,20 @@ class RedoOCLCForThreeMScript(Script):
                 edition.add_contributor(contribution.contributor, contribution.role)
 
 
-class CollectionGeneratorScript(Script):
-    """Creates a new Collection object and prints client details to STDOUT"""
+class CatalogGeneratorScript(Script):
+    """Creates a new Catalog object and prints client details to STDOUT"""
 
     def run(self, name):
         if not name:
-            ValueError("No name provided. Could not create collection.")
+            ValueError("No name provided. Could not create catalog.")
 
         name = " ".join(name)
-        print "Creating collection %s... " % name
-        collection, plaintext_client_secret = Collection.register(self._db, name)
+        print "Creating catalog %s... " % name
+        catalog, plaintext_client_secret = Catalog.register(self._db, name)
 
-        print collection
+        print catalog
         print ("RECORD THE FOLLOWING AUTHENTICATION DETAILS. "
                "The client secret cannot be recovered.")
         print "-" * 40
-        print "CLIENT ID: %s" % collection.client_id
+        print "CLIENT ID: %s" % catalog.client_id
         print "CLIENT SECRET: %s" % plaintext_client_secret

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -179,7 +179,7 @@ class TestCatalogController(DatabaseTest):
                 parser._xpath(uncatalogued, 'atom:id')[0].text)
             eq_(str(HTTP_NOT_FOUND),
                 parser._xpath(uncatalogued, 'simplified:status_code')[0].text)
-            eq_("Not in catalog catalog",
+            eq_("Not in catalog",
                 parser._xpath(uncatalogued, 'schema:description')[0].text)
 
             # It sends no <entry> tags.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -17,7 +17,7 @@ from core.util.opds_writer import OPDSMessage
 from core.opds_import import OPDSXMLParser
 
 from controller import (
-    CollectionController,
+    CatalogController,
     URNLookupController,
     HTTP_OK, 
     HTTP_CREATED, 
@@ -27,73 +27,73 @@ from controller import (
     HTTP_INTERNAL_SERVER_ERROR, 
 )
 
-class TestCollectionController(DatabaseTest):
+class TestCatalogController(DatabaseTest):
 
     def setup(self):
-        super(TestCollectionController, self).setup()
+        super(TestCatalogController, self).setup()
         from app import app
         self.app = app
 
-        self.controller = CollectionController(self._db)
-        self.collection = self._collection()
+        self.controller = CatalogController(self._db)
+        self.catalog = self._catalog()
         self.valid_auth = 'Basic ' + base64.b64encode('abc:def')
 
         self.work1 = self._work(with_license_pool=True, with_open_access_download=True)
         self.work2 = self._work(with_license_pool=True, with_open_access_download=True)
 
-    def test_authenticated_collection_required(self):
-        # Returns collection if authentication is valid.
+    def test_authenticated_catalog_required(self):
+        # Returns catalog if authentication is valid.
         with self.app.test_request_context('/',
                 headers=dict(Authorization=self.valid_auth)):
-            result = self.controller.authenticated_collection_from_request()
-            eq_(result, self.collection)
+            result = self.controller.authenticated_catalog_from_request()
+            eq_(result, self.catalog)
         
         # Returns error if authentication is invalid.
         invalid_auth = 'Basic ' + base64.b64encode('abc:defg')
         with self.app.test_request_context('/',
                 headers=dict(Authorization=invalid_auth)):
-            result = self.controller.authenticated_collection_from_request()
+            result = self.controller.authenticated_catalog_from_request()
             eq_(True, isinstance(result, ProblemDetail))
             eq_(HTTP_UNAUTHORIZED, result.status_code)
 
         # Returns errors without authentication.
         with self.app.test_request_context('/'):
-            result = self.controller.authenticated_collection_from_request()
+            result = self.controller.authenticated_catalog_from_request()
             eq_(True, isinstance(result, ProblemDetail))
 
-    def test_authenticated_collection_optional(self):
-        # Returns collection of authentication is valid.
+    def test_authenticated_catalog_optional(self):
+        # Returns catalog of authentication is valid.
         with self.app.test_request_context('/',
                 headers=dict(Authorization=self.valid_auth)):
-            result = self.controller.authenticated_collection_from_request(required=False)
-            eq_(result, self.collection)
+            result = self.controller.authenticated_catalog_from_request(required=False)
+            eq_(result, self.catalog)
         
         # Returns error if attempted authentication is invalid.
         invalid_auth = 'Basic ' + base64.b64encode('abc:defg')
         with self.app.test_request_context('/',
                 headers=dict(Authorization=invalid_auth)):
-            result = self.controller.authenticated_collection_from_request(required=False)
+            result = self.controller.authenticated_catalog_from_request(required=False)
             eq_(True, isinstance(result, ProblemDetail))
             eq_(HTTP_UNAUTHORIZED, result.status_code)
 
         # Returns none if no authentication.
         with self.app.test_request_context('/'):
-            result = self.controller.authenticated_collection_from_request(required=False)
+            result = self.controller.authenticated_catalog_from_request(required=False)
             eq_(None, result)
 
     def test_updates_feed(self):
         identifier = self.work1.license_pools[0].identifier
-        self.collection.catalog_identifier(self._db, identifier)
+        self.catalog.catalog_identifier(self._db, identifier)
 
         with self.app.test_request_context('/',
                 headers=dict(Authorization=self.valid_auth)):
             response = self.controller.updates_feed()
-            # The collection's updates feed is returned.
+            # The catalog's updates feed is returned.
             eq_(HTTP_OK, response.status_code)
             feed = feedparser.parse(response.get_data())
-            eq_(feed['feed']['title'],"%s Updates" % self.collection.name)
+            eq_(feed['feed']['title'],"%s Updates" % self.catalog.name)
             
-            # The feed has the collection's catalog.
+            # The feed has the catalog's catalog.
             eq_(1, len(feed['entries']))
             [entry] = feed['entries']
             eq_(self.work1.title, entry['title'])
@@ -110,7 +110,7 @@ class TestCollectionController(DatabaseTest):
             response = self.controller.updates_feed()
             eq_(HTTP_OK, response.status_code)
             feed = feedparser.parse(response.get_data())
-            eq_(feed['feed']['title'],"%s Updates" % self.collection.name)
+            eq_(feed['feed']['title'],"%s Updates" % self.catalog.name)
             # The timestamp is included in the url.
             linkified_timestamp = time.strftime("%Y-%m-%d+%H:%M:%S").replace(":", "%3A")
             assert feed['feed']['id'].endswith(linkified_timestamp)
@@ -130,7 +130,7 @@ class TestCollectionController(DatabaseTest):
 
     def test_updates_feed_is_paginated(self):
         for work in [self.work1, self.work2]:
-            self.collection.catalog_identifier(
+            self.catalog.catalog_identifier(
                 self._db, work.license_pools[0].identifier
             )
         with self.app.test_request_context('/?size=1',
@@ -153,7 +153,7 @@ class TestCollectionController(DatabaseTest):
         invalid_urn = "FAKE AS I WANNA BE"
         catalogued_id = self._identifier()
         uncatalogued_id = self._identifier()
-        self.collection.catalog_identifier(self._db, catalogued_id)
+        self.catalog.catalog_identifier(self._db, catalogued_id)
 
         parser = OPDSXMLParser()
         message_path = '/atom:feed/simplified:message'
@@ -179,20 +179,20 @@ class TestCollectionController(DatabaseTest):
                 parser._xpath(uncatalogued, 'atom:id')[0].text)
             eq_(str(HTTP_NOT_FOUND),
                 parser._xpath(uncatalogued, 'simplified:status_code')[0].text)
-            eq_("Not in collection catalog",
+            eq_("Not in catalog catalog",
                 parser._xpath(uncatalogued, 'schema:description')[0].text)
 
             # It sends no <entry> tags.
             eq_([], parser._xpath(root, "//atom:entry"))
 
             # The catalogued identifier isn't in the catalog.
-            assert catalogued_id not in self.collection.catalog
+            assert catalogued_id not in self.catalog.catalog
             # But it's still in the database.
             eq_(catalogued_id, self._db.query(Identifier).filter_by(
                 id=catalogued_id.id).one())
 
         # Try again, this time including an invalid URN.
-        self.collection.catalog_identifier(self._db, catalogued_id)
+        self.catalog.catalog_identifier(self._db, catalogued_id)
         with self.app.test_request_context(
                 '/?urn=%s&urn=%s' % (invalid_urn, catalogued_id.urn),
                 headers=dict(Authorization=self.valid_auth)):
@@ -220,7 +220,7 @@ class TestCollectionController(DatabaseTest):
             eq_([], parser._xpath(root, "//atom:entry"))
             
             # The catalogued identifier is still removed.
-            assert catalogued_id not in self.collection.catalog
+            assert catalogued_id not in self.catalog.catalog
 
 
 class TestURNLookupController(DatabaseTest):
@@ -325,27 +325,27 @@ class TestURNLookupController(DatabaseTest):
         self.controller.process_urn(identifier.urn)
         eq_([(identifier, work)], self.controller.works)
         
-    def test_process_urn_with_collection(self):
-        collection = self._collection()
+    def test_process_urn_with_catalog(self):
+        catalog = self._catalog()
         i1 = self._identifier()
         i2 = self._identifier()
 
-        eq_([], collection.catalog)
-        self.controller.process_urn(i1.urn, collection=collection)
-        eq_(1, len(collection.catalog))
-        eq_([i1], collection.catalog)
+        eq_([], catalog.catalog)
+        self.controller.process_urn(i1.urn, catalog=catalog)
+        eq_(1, len(catalog.catalog))
+        eq_([i1], catalog.catalog)
 
         # Adds new identifiers to an existing catalog
-        self.controller.process_urn(i2.urn, collection=collection)
-        eq_(2, len(collection.catalog))
-        assert i1 in collection.catalog
-        assert i2 in collection.catalog
+        self.controller.process_urn(i2.urn, catalog=catalog)
+        eq_(2, len(catalog.catalog))
+        assert i1 in catalog.catalog
+        assert i2 in catalog.catalog
 
         # Does not duplicate identifiers in the catalog
-        self.controller.process_urn(i1.urn, collection=collection)
-        eq_(2, len(collection.catalog))
-        assert i1 in collection.catalog
-        assert i2 in collection.catalog
+        self.controller.process_urn(i1.urn, catalog=catalog)
+        eq_(2, len(catalog.catalog))
+        assert i1 in catalog.catalog
+        assert i2 in catalog.catalog
 
     def test_process_urn_isbn(self):
         # Create a new ISBN identifier.


### PR DESCRIPTION
This branch makes sure my change to https://github.com/NYPL-Simplified/server_core/pull/465 (renaming `Collection` to `Catalog` so I can add a different `Collection` class) doesn't break any metadata wrangler code. I basically do this by renaming 'collection' to 'catalog' everywhere.

Note that the core branch drops the `collections` and `collectionidentifiers` tables so they can be recreated under new names. Since there are no collections currently in the metadata wrangler database, I figure it's safe.