### PR TITLE
Update for collection changes in core

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -100,7 +100,7 @@ class TestCatalogController(ControllerTest):
         self.controller = CatalogController(self._db)
 
         # The collection as it exists on the circulation manager.
-        remote_collection = self._collection(username='test_coll', url=self._url)
+        remote_collection = self._collection(username='test_coll', external_account_id=self._url)
         # The collection as it is recorded / catalogued here.
         self.collection = self._collection(
             name=remote_collection.metadata_identifier,


### PR DESCRIPTION
In https://github.com/NYPL-Simplified/server_core/pull/484, I moved the URL for OPDS Import collections into external_account_id, so external_account_id can always be the unique identifier for the collection. I had to make one tiny change to a test in here.