### PR TITLE
Mirror and script fixes

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -652,3 +652,4 @@ class IntegrationClientGeneratorScript(Script):
         print "-" * 40
         print "CLIENT KEY: %s" % client
         print "CLIENT SECRET: %s" % plaintext_secret
+        self._db.commit()

--- a/scripts.py
+++ b/scripts.py
@@ -650,6 +650,6 @@ class IntegrationClientGeneratorScript(Script):
         print ("RECORD THE FOLLOWING AUTHENTICATION DETAILS. "
                "The client secret cannot be recovered.")
         print "-" * 40
-        print "CLIENT KEY: %s" % client
+        print "CLIENT KEY: %s" % client.key
         print "CLIENT SECRET: %s" % plaintext_secret
         self._db.commit()


### PR DESCRIPTION
This fixes a couple problems I found while working on mirroring covers from the circulation manager:

- The script to create IntegrationClients was never committing.
- The code to mirror a link wasn't fetching the content of a link if there was already a Representation, and Identifier.add_link creates a Representation without fetching the content if there's a media type.