### PR TITLE
Track unauthenticated lookups in a new "unaffiliated" collection

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -485,7 +485,7 @@ class URNLookupController(CoreURNLookupController):
             return self.add_work(identifier, work)
 
         # Work remains to be done.
-        return self.register_identifier_as_unresolved(urn, identifier, collection)
+        return self.register_identifier_as_unresolved(urn, identifier)
 
     def register_identifier_as_unresolved(self, urn, identifier):
         # This identifier could have a presentation-ready Work

--- a/controller.py
+++ b/controller.py
@@ -463,7 +463,6 @@ class URNLookupController(CoreURNLookupController):
         # If a Collection was provided by an authenticated IntegrationClient,
         # this Identifier is part of the Collection's catalog.
         client = authenticated_client_from_request(self._db, required=False)
-        collection = None
         if client and collection_details:
             collection, ignore = Collection.from_metadata_identifier(
                 self._db, collection_details

--- a/controller.py
+++ b/controller.py
@@ -500,8 +500,7 @@ class URNLookupController(CoreURNLookupController):
         collection, ignore = IdentifierResolutionCoverageProvider.unaffiliated_collection(
             self._db
         )
-        if identifier not in collection.catalog:
-            collection.catalog.append(identifier)
+        collection.catalog.append(identifier)
         
         record = CoverageRecord.lookup(identifier, source, self.OPERATION)
         is_new = False

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -465,6 +465,19 @@ class TestURNLookupController(ControllerTest):
         )
         eq_([identifier], unaffiliated.catalog)
 
+    @basic_request_context
+    def test_register_identifier_as_unresolved_does_not_catalog_already_cataloged_identifier(self):
+        # This identifier is already in a Collection's catalog.
+        identifier = self._identifier()
+        collection = self._collection()
+        collection.catalog.append(identifier)
+
+        # Registering it as unresolved doesn't also add it to the
+        # 'unaffiliated' Collection.
+        self.controller.register_identifier_as_unresolved(
+            identifier.urn, identifier
+        )
+        eq_([collection], identifier.collections)
 
     @basic_request_context
     def test_process_urn_pending_resolve_attempt(self):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -40,6 +40,7 @@ from controller import (
     authenticated_client_from_request,
 )
 
+from coverage import IdentifierResolutionCoverageProvider
 
 class ControllerTest(DatabaseTest):
 
@@ -457,6 +458,14 @@ class TestURNLookupController(ControllerTest):
         [coverage] = identifier.coverage_records
         eq_(CoverageRecord.TRANSIENT_FAILURE, coverage.status)
 
+        # The Identifier has been added to the catalog of the
+        # "Unaffiliated" collection.
+        unaffiliated, ignore = IdentifierResolutionCoverageProvider.unaffiliated_collection(
+            self._db
+        )
+        eq_([identifier], unaffiliated.catalog)
+
+
     @basic_request_context
     def test_process_urn_pending_resolve_attempt(self):
         # Simulate calling process_urn twice, and make sure the 
@@ -474,6 +483,13 @@ class TestURNLookupController(ControllerTest):
             identifier.urn, HTTP_ACCEPTED,
             URNLookupController.WORKING_TO_RESOLVE_IDENTIFIER
         )
+
+        # The Identifier is only present once in the catalog of the
+        # "Unaffiliated" collection.
+        unaffiliated, ignore = IdentifierResolutionCoverageProvider.unaffiliated_collection(
+            self._db
+        )
+        eq_([identifier], unaffiliated.catalog)
 
     @basic_request_context
     def test_process_urn_exception_during_resolve_attempt(self):

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -212,6 +212,9 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
             self._db, None, self.viaf, api=self.linked_data_client
         )
         self.uploader = DummyS3Uploader()
+        self.mock_content_cafe = ContentCafeAPI(
+            self._db, None, object(), object(), self.uploader
+        )
 
         # Make the constructor arguments available in case a test
         # needs to create a different type of resolver.
@@ -234,6 +237,22 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
         self.never_successful = NeverSuccessfulCoverageProvider(self._db)
         self.broken = BrokenCoverageProvider(self._db)
 
+    def test_all(self):
+        # We have 2 collections created during setup, plus 3 more
+        # created here, plus the 'unaffiliated' collection.
+        unaffiliated, ignore = IdentifierResolutionCoverageProvider.unaffiliated_collection(self._db)
+        for i in range(3):
+            collection = self._collection()
+
+        # all() puts them in random order (not tested), but
+        # the unaffiliated collection is always last.
+        providers = IdentifierResolutionCoverageProvider.all(
+            self._db, uploader=self.uploader, 
+            content_cafe_api=self.mock_content_cafe,
+        )
+        eq_(6, len(providers))
+        eq_(unaffiliated, providers[-1].collection)
+
     def test_providers_opds(self):
         # For an OPDS collection that goes against the open-access content
         # server...
@@ -243,11 +262,8 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
         uploader = object()
         # In lieu of a proper mock API, create one that will crash
         # if it tries to make a real HTTP request.
-        mock_content_cafe = ContentCafeAPI(
-            self._db, None, object(), object(), self.uploader
-        )
         resolver = IdentifierResolutionCoverageProvider(
-            self._default_collection, content_cafe_api=mock_content_cafe,
+            self._default_collection, content_cafe_api=self.mock_content_cafe,
             uploader=uploader
         )
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -289,7 +289,7 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
         assert isinstance(content_cafe, ContentCafeCoverageProvider)
         assert isinstance(oclc_classify, OCLCClassifyCoverageProvider)
         assert isinstance(opds, LookupClientCoverageProvider)
-        eq_(mock_content_cafe, content_cafe.content_cafe)
+        eq_(self.mock_content_cafe, content_cafe.content_cafe)
         eq_(self._default_collection, opds.collection)
         
     def test_providers_overdrive(self):

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -237,6 +237,21 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
         self.never_successful = NeverSuccessfulCoverageProvider(self._db)
         self.broken = BrokenCoverageProvider(self._db)
 
+    def test_unaffiliated_collection(self):
+        """A special collection exists to track Identifiers not affiliated
+        with any collection associated with a particular library.
+        """
+        m = IdentifierResolutionCoverageProvider.unaffiliated_collection
+        unaffiliated, is_new = m(self._db)
+        eq_(True, is_new)
+        eq_("Unaffiliated Identifiers", unaffiliated.name)
+        eq_(DataSource.INTERNAL_PROCESSING, unaffiliated.protocol)
+
+        unaffiliated2, is_new = m(self._db)
+        eq_(unaffiliated, unaffiliated2)
+        eq_(False, is_new)
+
+
     def test_all(self):
         # We have 2 collections created during setup, plus 3 more
         # created here, plus the 'unaffiliated' collection.


### PR DESCRIPTION
This branch makes sure that all identifiers that come in to be resolved are associated with some collection. Identifiers that come in through unauthenticated lookup are added to a new collection called 'Unaffiliated Identifiers'. 

This guarantees that the `IdentifierResolutionCoverageProvider` will eventually process these identifiers, though it only gets to that collection after it's caught up on all other collections.