### PR TITLE
Shorten request time

### DIFF
--- a/bin/register_identifiers
+++ b/bin/register_identifiers
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""Register identifiers for resolution."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from core.scripts import RunCoverageProvidersScript 
+from coverage import IdentifierResolutionRegistrar
+
+RunCoverageProvidersScript([IdentifierResolutionRegistrar]).run()


### PR DESCRIPTION
Register identifiers for registration coverage that will register them for metadata coverage 🤕 . This is an attempt to resolve #134 by pushing off the act of actually creating register-status coverage records out of the request window.

The error might also be alleviated by sending smaller batches from the circulation manager or extending the timeout there, but circulation manager changes take longer to propagate to partner servers.

I'd like to have `bin/register_identifiers` run every 10-15 minutes on the metadata wrangler.