### PR TITLE
Fix updates feed

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -229,8 +229,8 @@ class CatalogController(object):
         entries = []
         for work in works[:]:
             entry = work.verbose_opds_entry or work.simple_opds_entry
-            entry = etree.fromstring(entry)
             if entry:
+                entry = etree.fromstring(entry)
                 entries.append(entry)
                 works.remove(work)
 


### PR DESCRIPTION
This fixes a small error that kept the updates feeds from building properly.

It also adds ISBN entries to the feed as well. When lookup was returning OPDS, this wasn't as important, but now that the updates feed is the only way to get collection info, ISBNs have to be able to return cover links, even if OCLC doesn't result in a work.