### PR TITLE
Make sure to load all configuration from the database before handling the first request.

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,6 +46,7 @@ def initialize_database(autoinitialize=True):
     if autoinitialize:
         SessionManager.initialize_data(_db)
 
+    Configuration.load(_db)
     log_level = LogConfiguration.initialize(_db, testing=testing)
     if app.debug is None:
         debug = log_level == 'DEBUG'


### PR DESCRIPTION
This bit of code got lost because in the circulation manager it's not run in the before-the-first-request hook method -- the CirculationManager object runs it, and there's no equivalent in the metadata wrangler yet.