### PR TITLE
Fix recurring coverage errors

### DIFF
--- a/content_server.py
+++ b/content_server.py
@@ -22,7 +22,7 @@ class LookupClientCoverageProvider(CatalogCoverageProvider):
     """
 
     # TODO: We should rename this because in theory it can be used
-    # other places, but in practice this is it. If this every changes in
+    # other places, but in practice this is it. If this ever changes in
     # practice, COVERAGE_COUNTS_FOR_EVERY_COLLECTION should also be set to
     # False.
     SERVICE_NAME = "OA Content Server Coverage Provider"

--- a/content_server.py
+++ b/content_server.py
@@ -22,10 +22,13 @@ class LookupClientCoverageProvider(CatalogCoverageProvider):
     """
 
     # TODO: We should rename this because in theory it can be used
-    # other places, but in practice this is it.
+    # other places, but in practice this is it. If this every changes in
+    # practice, COVERAGE_COUNTS_FOR_EVERY_COLLECTION should also be set to
+    # False.
     SERVICE_NAME = "OA Content Server Coverage Provider"
+    COVERAGE_COUNTS_FOR_EVERY_COLLECTION = True
     PROTOCOL = ExternalIntegration.OPDS_IMPORT
-    
+
     OPDS_SERVER_RETURNED_WRONG_CONTENT_TYPE = "OPDS Server served unhandleable media type: %s"
    
     def __init__(self, collection, **kwargs):

--- a/coverage.py
+++ b/coverage.py
@@ -442,7 +442,9 @@ class IdentifierResolutionRegistrar(CatalogCoverageProvider):
                 lambda c: c.protocol==provider.PROTOCOL, identifier.collections
             )
             if covered_collections:
-                if provider==LookupClientCoverageProvider:
+                if (provider==LookupClientCoverageProvider or
+                    not provider.COVERAGE_COUNTS_FOR_EVERY_COLLECTION
+                ):
                     # The LookupClientCoverageProvider doesn't have an obvious
                     # data source. It uses the collection's data source instead.
                     for collection in covered_collections:

--- a/integration_client.py
+++ b/integration_client.py
@@ -18,6 +18,7 @@ class IntegrationClientCoverageProvider(CatalogCoverageProvider):
 
     OPERATION = CoverageRecord.IMPORT_OPERATION
     PROTOCOL = ExternalIntegration.OPDS_FOR_DISTRIBUTORS
+    COVERAGE_COUNTS_FOR_EVERY_COLLECTION = False
 
     def __init__(self, uploader, collection, *args, **kwargs):
         self.uploader = uploader

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 # Core requirements
 pillow
 psycopg2
-requests
-sqlalchemy>=1.0.6
+requests==2.18.4
+sqlalchemy==1.1.15
 nose
 lxml
 flask
 textblob
 isbnlib
-tinys3==0.1.11
+tinys3==0.1.12
 feedparser
 elasticsearch
 uwsgi

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ py-bcrypt
 # for author name matching
 nameparser
 fuzzywuzzy
+python-Levenshtein

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -78,6 +78,7 @@ class TestLookupClientCoverageProvider(DatabaseTest):
         self._default_collection.external_integration.set_setting(
             Collection.DATA_SOURCE_NAME_SETTING, DataSource.OA_CONTENT_SERVER
         )
+        self._default_collection.external_account_id = self._url
         self.provider = MockLookupClientCoverageProvider(
             self._default_collection
         )
@@ -199,6 +200,7 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
 
         # Create mocks for the different collections and APIs used by
         # IdentifierResolutionCoverageProvider.
+        self._default_collection.external_account_id = self._url
         overdrive_collection = MockOverdriveAPI.mock_collection(self._db)
         overdrive_collection.name = (
             IdentifierResolutionCoverageProvider.DEFAULT_OVERDRIVE_COLLECTION_NAME

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -582,11 +582,17 @@ class TestIdentifierResolutionRegistrar(DatabaseTest):
         self.identifier.collections.extend([opds_distrib, opds_import])
         self.registrar.process_item(self.identifier)
 
+        # A CoverageRecord is created for the OA content server.
+        [oa_content] = [cr for cr in self.identifier.coverage_records
+                        if cr.data_source.name==DataSource.OA_CONTENT_SERVER]
+        # It doesn't have a collection, even though it used a collection
+        # to provide a DataSource.
+        eq_(None, oa_content.collection)
+
+        # There should be an additional DataSource.INTERNAL_PROCESSING
+        # record for the OPDS_FOR_DISTRIBUTORS coverage.
         source_names = [cr.data_source.name
                         for cr in self.identifier.coverage_records]
-        assert DataSource.OA_CONTENT_SERVER in source_names
-        # There should now be an additional DataSource.INTERNAL_PROCESSING
-        # record for the OPDS_FOR_DISTRIBUTORS coverage.
         eq_(2, source_names.count(DataSource.INTERNAL_PROCESSING))
 
     def test_process_item_creates_an_active_license_pool(self):


### PR DESCRIPTION
This branch uses `IdentifierCoverageProvider.COUNTS_COVERAGE_FOR_EVERY_COLLECTION` to reason about how CoverageRecords should be created, and incorporates a change in core to fix a recurring error getting open access coverage (NYPL-Simplified/server_core#740).

It also pumps up the requests and tinys3 versions in (unfounded) hopes of fixing a recurring dependency error in Content Cafe coverage that I haven't been able to recreate locally.

I'm also pumping up the sqlalchemy version because we've been at 1.0.6 for a bit, and the current sqlalchemy release is 1.1. I ran both metadata and circulation tests on a branch new database using this sqlalchemy version, and I didn't hit any hiccups.

The python-Levenshtein package removes a fuzzywuzzy package warning.