### PR TITLE
Update add with metadata

### DIFF
--- a/bin/work_presentation_coverage
+++ b/bin/work_presentation_coverage
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""Gather information from OCLC Linked Data."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from integration_client import WorkPresentationCoverageProvider
+from core.scripts import RunWorkCoverageProviderScript
+
+RunWorkCoverageProviderScript(WorkPresentationCoverageProvider).run()

--- a/bin/work_presentation_coverage
+++ b/bin/work_presentation_coverage
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Gather information from OCLC Linked Data."""
+"""Calculate Work presentation for registered works."""
 import os
 import sys
 bin_dir = os.path.split(__file__)[0]

--- a/content_cafe.py
+++ b/content_cafe.py
@@ -37,7 +37,7 @@ class ContentCafeCoverageProvider(IdentifierCoverageProvider):
     
     def __init__(self, _db, api=None, uploader=None, **kwargs):
         super(ContentCafeCoverageProvider, self).__init__(
-            _db, preregistered_only=True, **kwargs
+            _db, registered_only=True, **kwargs
         )
         if api:
             self.content_cafe = api

--- a/controller.py
+++ b/controller.py
@@ -393,14 +393,14 @@ class CatalogController(ISBNEntryMixin):
             self._db, client, collection_details
         )
 
+        data_source = DataSource.lookup(
+            self._db, collection.name, autocreate=True
+        )
+
         messages = []
 
         feed = feedparser.parse(request.data)
         entries = feed.get("entries", [])
-
-        if not client.data_source:
-            client.data_source = DataSource.lookup(self._db, client.url, autocreate=True)
-        data_source = client.data_source
 
         for entry in entries:
             urn = entry.get('id')

--- a/coverage.py
+++ b/coverage.py
@@ -101,7 +101,7 @@ class IdentifierResolutionCoverageProvider(CatalogCoverageProvider):
     ):
 
         super(IdentifierResolutionCoverageProvider, self).__init__(
-            collection, preregistered_only=True, **kwargs
+            collection, registered_only=True, **kwargs
         )
 
         # Since we are the metadata wrangler, any resources we find,

--- a/integration_client.py
+++ b/integration_client.py
@@ -27,6 +27,11 @@ class WorkPresentationCoverageProvider(WorkCoverageProvider):
 
     _policy = None
 
+    def __init__(self, *args, **kwargs):
+        if not 'registered_only' in kwargs:
+            kwargs['registered_only'] = True
+        super(WorkPresentationCoverageProvider, self).__init__(*args, **kwargs)
+
     @property
     def policy(self):
         # We're going to be aggressive about recalculating the presentation

--- a/integration_client.py
+++ b/integration_client.py
@@ -115,7 +115,9 @@ class CalculatesWorkPresentation(object):
         pass
 
 
-class IntegrationClientCoverageProvider(CatalogCoverageProvider):
+class IntegrationClientCoverageProvider(CatalogCoverageProvider,
+    CalculatesWorkPresentation
+):
     """Mirrors and scales cover images we heard about from an IntegrationClient."""
 
     SERVICE_NAME = "Integration Client Coverage Provider"
@@ -140,4 +142,9 @@ class IntegrationClientCoverageProvider(CatalogCoverageProvider):
         replace = ReplacementPolicy(mirror=self.uploader, links=True)
         metadata = Metadata.from_edition(edition)
         metadata.apply(edition, self.collection, replace=replace)
+
+        failure = self.register_work_for_calculation(identifier)
+        if failure:
+            return failure
+
         return identifier

--- a/integration_client.py
+++ b/integration_client.py
@@ -3,12 +3,117 @@ from core.model import (
     CoverageRecord,
     DataSource,
     ExternalIntegration,
+    PresentationCalculationPolicy,
 )
-from core.coverage import CatalogCoverageProvider
+from core.coverage import (
+    CatalogCoverageProvider,
+    WorkCoverageProvider,
+)
 from core.metadata_layer import (
     Metadata,
     ReplacementPolicy,
 )
+
+
+class WorkPresentationCoverageProvider(WorkCoverageProvider):
+
+    """A CoverageProvider to reset the presentation for a Work as it
+    achieves metadata coverage.
+    """
+
+    SERVICE_NAME = "Work Presentation Coverage Provider"
+    OPERATION = "recalculate-presentation"
+    DEFAULT_BATCH_SIZE = 25
+
+    _policy = None
+
+    @property
+    def policy(self):
+        # We're going to be aggressive about recalculating the presentation
+        # for this work because either the work is currently not calculated
+        # at all, or new metadata has been added that may impact the work, or
+        # something went wrong trying to calculate it last time.
+        if not self._policy:
+            self._policy = PresentationCalculationPolicy(
+                regenerate_opds_entries=True
+            )
+        return self._policy
+
+    def process_item(self, work):
+        work.calculate_presentation(
+            policy=self.policy, exclude_search=True,
+            default_fiction=None, default_audience=None,
+        )
+        work.set_presentation_ready(exclude_search=True)
+
+
+class CalculatesWorkPresentation(object):
+
+    """A mixin for IdentifierCoverageProvider (and its subclasses) that
+    registers a Work to have its presentation calculated or recalculated.
+    """
+
+    INCALCULABLE_WORK = "500: Work could not be calculated for %r"
+
+    def register_work_for_calculation(self, identifier):
+        """Registers the given identifier's work for presentation calculation
+        with the WorkPresentationCoverageProvider.
+
+        :return: None, if successful, or CoverageFailure
+        """
+        work = self.get_work(identifier)
+        if not work:
+            return self.no_work_found_failure(identifier)
+
+        failure = self.update_work_presentation(work, identifier)
+        if failure:
+            return failure
+
+    def get_work(self, identifier):
+        """Finds or calculates a work for a given identifier.
+
+        :return: Work or None
+        """
+        work = identifier.work
+        if work:
+            return work
+
+        # Calculate the work directly from a LicensePool.
+        license_pools = identifier.licensed_through
+        if license_pools:
+            pool = license_pools[0]
+            work, created = pool.calculate_work(
+                even_if_no_author=True, exclude_search=True,
+            )
+            if work:
+                return work
+
+        # A work couldn't be found or created.
+        return None
+
+    def no_work_found_failure(self, identifier):
+        """Returns a CoverageFailure in the case that a Work can't be
+        found or created for an identifier.
+        """
+        return self.failure(identifier, self.INCALCULABLE_WORK % identifier)
+
+    def update_work_presentation(self, work, identifier):
+        """Register this work to have its presentation calculated
+
+        :return: None, if successful, or CoverageFailure
+        """
+        try:
+            self.presentation_calculation_pre_hook(work)
+        except Exception as e:
+            return self.failure(identifier, repr(e), transient=True)
+        WorkPresentationCoverageProvider.register(work, force=True)
+
+    def presentation_calculation_pre_hook(self, work):
+        """An optional hook method to prepare the discovered Work for
+        presentation calculation.
+        """
+        pass
+
 
 class IntegrationClientCoverageProvider(CatalogCoverageProvider):
     """Mirrors and scales cover images we heard about from an IntegrationClient."""

--- a/migration/20171012-2-register-identifiers-for-resolution.py
+++ b/migration/20171012-2-register-identifiers-for-resolution.py
@@ -34,7 +34,7 @@ class MockResolver(IdentifierResolutionCoverageProvider):
     """
     def __init__(self, collection):
         super(IdentifierResolutionCoverageProvider, self).__init__(
-            collection, preregistered_only=True
+            collection, registered_only=True
         )
 
 try:

--- a/oclc.py
+++ b/oclc.py
@@ -931,7 +931,7 @@ class LinkedDataCoverageProvider(IdentifierCoverageProvider):
         else:
             self.viaf = VIAFClient(_db)
 
-        kwargs['preregistered_only'] = True
+        kwargs['registered_only'] = True
         super(LinkedDataCoverageProvider, self).__init__(_db, *args, **kwargs)
             
     def process_item(self, identifier):

--- a/oclc_classify.py
+++ b/oclc_classify.py
@@ -609,7 +609,7 @@ class OCLCClassifyCoverageProvider(IdentifierCoverageProvider):
     
     def __init__(self, _db, api=None, **kwargs):
         super(OCLCClassifyCoverageProvider, self).__init__(
-            _db, preregistered_only=True, **kwargs
+            _db, registered_only=True, **kwargs
         )
         self.api = api or OCLCClassifyAPI(self._db)
 

--- a/overdrive.py
+++ b/overdrive.py
@@ -20,7 +20,7 @@ class OverdriveBibliographicCoverageProvider(
     def __init__(self, collection, uploader=None, **kwargs):
         _db = Session.object_session(collection)
         self.mirror = uploader or S3Uploader.from_config(_db)
-        kwargs['preregistered_only'] = True
+        kwargs['registered_only'] = True
         super(OverdriveBibliographicCoverageProvider, self).__init__(
             collection, **kwargs
         )

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -18,6 +18,7 @@ from core.model import (
     get_one, 
     Identifier,
     LicensePool,
+    Work,
 )
 from core.opds_import import (
     MockSimplifiedOPDSLookup,
@@ -45,6 +46,7 @@ from coverage import (
 )
 from integration_client import (
     IntegrationClientCoverageProvider,
+    WorkPresentationCoverageProvider,
 )
 from oclc_classify import (
     OCLCClassifyCoverageProvider, 
@@ -354,7 +356,7 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
         self.resolver.process_item(licensed)
         eq_([lp], licensed.licensed_through)
 
-    def test_process_item_may_create_work(self):
+    def test_process_item_uses_viaf_to_determine_author_name(self):
         self.resolver.required_coverage_providers = [
             self.always_successful
         ]
@@ -363,19 +365,26 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
             identifier_id=self.identifier.identifier,
             authors=['Mindy K']
         )
-        
+        [original_contributor] = edition.contributors
+        eq_('K, Mindy', original_contributor.sort_name)
+
         self.resolver.process_item(self.identifier)
         [lp] = self.identifier.licensed_through
         eq_(True, isinstance(lp, LicensePool))
         eq_(lp.collection, self.resolver.collection)
         eq_(lp.data_source, self.resolver.data_source)
 
-        # Because this book had a presentation Edition, we were able
-        # to create a Work.
-        eq_(edition.title, lp.work.title)
+        # Because this book had a presentation edition, a work was
+        # generated.
+        work = self.identifier.work
+        assert isinstance(work, Work)
+        eq_(edition, work.presentation_edition)
+        eq_(edition.title, work.title)
 
-        # VIAF improved the name of the author.
-        eq_("Mindy Kaling", lp.work.author)
+        # VIAF updated the same contributor object with better name data.
+        eq_([original_contributor], list(edition.contributors))
+        eq_("Kaling, Mindy", original_contributor.sort_name)
+        eq_("Mindy Kaling", original_contributor.display_name)
 
     def test_run_through_relevant_providers(self):
         providers = [self.always_successful, self.never_successful]
@@ -437,20 +446,6 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
         eq_(True, isinstance(result, CoverageFailure))
         eq_(True, result.transient)
 
-    def test_process_item_fails_when_finalize_raises_exception(self):
-        class FinalizeAlwaysFails(MockIdentifierResolutionCoverageProvider):
-            def finalize(self, unresolved_identifier):
-                raise Exception("Oh no!")
-
-        provider = FinalizeAlwaysFails(
-            self._default_collection, **self.provider_kwargs
-        )
-        result = provider.process_item(self.identifier)
-
-        eq_(True, isinstance(result, CoverageFailure))
-        assert "Oh no!" in result.exception
-        eq_(True, result.transient)
-
     def test_process_item_succeeds_when_optional_provider_fails(self):
         # Give the identifier an edition so a work can be created.
         edition = self._edition(
@@ -477,6 +472,26 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
             CoverageRecord.identifier==self.identifier,
             CoverageRecord.operation==self.never_successful.OPERATION).one()
         eq_("What did you expect?", r.exception)
+
+    def test_process_item_registers_work_for_calculation(self):
+        # Give the identifier an edition so a work can be created.
+        edition = self._edition(
+            identifier_type=self.identifier.type,
+            identifier_id=self.identifier.identifier
+        )
+
+        self.resolver.required_coverage_providers = [self.always_successful]
+        result = self.resolver.process_item(self.identifier)
+
+        eq_(result, self.identifier)
+
+        # The identifier has been given a work.
+        work = self.identifier.work
+        assert isinstance(work, Work)
+
+        # The work has a WorkCoverageRecord for presentation calculation.
+        [record] = [r for r in work.coverage_records
+                    if r.operation==WorkPresentationCoverageProvider.OPERATION]
 
 
 class TestIdentifierResolutionRegistrar(DatabaseTest):

--- a/tests/test_integration_client.py
+++ b/tests/test_integration_client.py
@@ -4,17 +4,147 @@ from nose.tools import (
     assert_raises,
 )
 
-from core.s3 import DummyS3Uploader
-
 from . import (
     DatabaseTest,
 )
 
-from core.model import ExternalIntegration
+from core.coverage import CoverageFailure
+from core.model import (
+    CoverageRecord,
+    ExternalIntegration,
+    PresentationCalculationPolicy,
+    Work,
+)
+from core.s3 import DummyS3Uploader
+from core.testing import AlwaysSuccessfulCoverageProvider
 
 from integration_client import (
+    CalculatesWorkPresentation,
     IntegrationClientCoverageProvider,
+    WorkPresentationCoverageProvider,
 )
+
+
+class TestWorkPresentationCoverageProvider(DatabaseTest):
+
+    def setup(self):
+        super(TestWorkPresentationCoverageProvider, self).setup()
+        self.provider = WorkPresentationCoverageProvider(self._db)
+
+    def test_default_policy(self):
+        # By default, the policy regenerates OPDS entries, in addition to
+        # the usual metadata calculation items.
+        original_policy = self.provider.policy
+        eq_(True, original_policy.regenerate_opds_entries)
+        eq_(True, original_policy.choose_edition)
+        eq_(True, original_policy.set_edition_metadata)
+        eq_(True, original_policy.classify)
+        eq_(True, original_policy.choose_summary)
+        eq_(True, original_policy.calculate_quality)
+        eq_(True, original_policy.choose_cover)
+
+    def test_policy_can_be_customized(self):
+        original_policy = self.provider.policy
+        new_policy = PresentationCalculationPolicy.reset_cover()
+
+        self.provider._policy = new_policy
+        eq_(new_policy, self.provider.policy)
+        eq_(False, self.provider.policy.regenerate_opds_entries)
+        eq_(False, self.provider.policy.choose_edition)
+
+    def test_process_item(self):
+        work = self._work()
+        eq_(None, work.simple_opds_entry)
+        eq_(None, work.verbose_opds_entry)
+
+        self.provider.process_item(work)
+
+        # The OPDS entries have been calculated.
+        assert work.simple_opds_entry != None
+        assert work.verbose_opds_entry != None
+
+
+class TestCalculatesWorkPresentation(DatabaseTest):
+
+    # Create a mock provider that uses the mixin.
+    class MockProvider(
+        AlwaysSuccessfulCoverageProvider, CalculatesWorkPresentation
+    ):
+        pass
+
+    def setup(self):
+        super(TestCalculatesWorkPresentation, self).setup()
+        self.provider = self.MockProvider(self._db)
+
+    def test_get_work(self):
+        # Without any means to a work, nothing is returned.
+        identifier = self._identifier()
+        eq_(None, self.provider.get_work(identifier))
+
+        # With a means to a work (LicensePool, Edition), a work is created and
+        # returned.
+        edition, lp = self._edition(
+            identifier_type=identifier.type,
+            identifier_id=identifier.identifier,
+            with_license_pool=True
+        )
+        result = self.provider.get_work(identifier)
+        assert isinstance(result, Work)
+        eq_(edition.title, result.title)
+
+        # A work that already exists can also be returned.
+        eq_(result, self.provider.get_work(identifier))
+
+    def test_no_work_found_failure(self):
+        identifier = self._identifier()
+        expected_msg = self.provider.INCALCULABLE_WORK % identifier
+
+        result = self.provider.no_work_found_failure(identifier)
+        assert isinstance(result, CoverageFailure)
+        eq_(identifier, result.obj)
+        eq_(expected_msg, result.exception)
+
+    def test_update_work_presentation(self):
+        work = self._work()
+        identifier = work.presentation_edition.primary_identifier
+        # The work is initialized with no coverage records.
+        eq_(0, len(work.coverage_records))
+
+        # It registers a work for presentation calculation.
+        result = self.provider.update_work_presentation(work, identifier)
+        eq_(None, result)
+        [record] = work.coverage_records
+        eq_(WorkPresentationCoverageProvider.OPERATION, record.operation)
+        eq_(CoverageRecord.REGISTERED, record.status)
+
+        # It returns the record to REGISTERED status, even if it already
+        # exists.
+        record.status = CoverageRecord.SUCCESS
+        self.provider.update_work_presentation(work, identifier)
+        eq_(CoverageRecord.REGISTERED, record.status)
+
+        # It runs a hook method, if it's defined.
+        new_title = "What's Love Gotta Do Wit It? (The 10-Part Saga)"
+        class HookMethodProvider(self.MockProvider):
+            def presentation_calculation_pre_hook(self, work):
+                work.presentation_edition.title = new_title
+        hook_provider = HookMethodProvider(self._db)
+
+        result = hook_provider.update_work_presentation(work, identifier)
+        eq_(None, result)
+        eq_(new_title, work.title)
+
+        # It returns a CoverageFailure if the hook method errors.
+        class FailedHookMethodProvider(self.MockProvider):
+            def presentation_calculation_pre_hook(self, work):
+                raise RuntimeError("Ack!")
+        failed_hook_provider = FailedHookMethodProvider(self._db)
+
+        result = failed_hook_provider.update_work_presentation(work, identifier)
+        assert isinstance(result, CoverageFailure)
+        eq_(identifier, result.obj)
+        assert "Ack!" in result.exception
+
 
 class TestIntegrationClientCoverageProvider(DatabaseTest):
 


### PR DESCRIPTION
This branch updates the `CatalogController.add_with_metadata` endpoint to depend on the IdentifierResolutionRegistrar. If an identifier is added to a new collection's catalog, then the IdentifierResolutionRegistrar will handle the creation of a LicensePool and CoverageRecord; the controller doesn't need to worry about it.

While I was doing that, I started thinking about the flow of an identifier as metadata is added. It's possible that an identifier is "resolved" on the whole, but that metadata is added via some collection *after* that point. So now there's a coverage provider to recalculate the work presentation and a way to incorporate it into IdentifierCoverageProvider subclasses.

Requires NYPL-Simplified/server_core#749.