### PR TITLE
Add endpoint to request metadata from the circulation manager

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,6 +125,14 @@ def add_with_metadata(collection_metadata_identifier):
         collection_details=collection_metadata_identifier
     )
 
+@app.route('/<collection_metadata_identifier>/metadata_requests', methods=['GET'])
+@requires_auth
+@returns_problem_detail
+def metadata_requests_for(collection_metadata_identifier):
+    return CatalogController(app._db).metadata_requests_for(
+        collection_details=collection_metadata_identifier
+    )
+
 @app.route('/<collection_metadata_identifier>/updates')
 @requires_auth
 @returns_problem_detail

--- a/app.py
+++ b/app.py
@@ -125,11 +125,11 @@ def add_with_metadata(collection_metadata_identifier):
         collection_details=collection_metadata_identifier
     )
 
-@app.route('/<collection_metadata_identifier>/metadata_requests', methods=['GET'])
+@app.route('/<collection_metadata_identifier>/metadata_needed', methods=['GET'])
 @requires_auth
 @returns_problem_detail
-def metadata_requests_for(collection_metadata_identifier):
-    return CatalogController(app._db).metadata_requests_for(
+def metadata_needed_for(collection_metadata_identifier):
+    return CatalogController(app._db).metadata_needed_for(
         collection_details=collection_metadata_identifier
     )
 

--- a/controller.py
+++ b/controller.py
@@ -158,8 +158,8 @@ class IndexController(object):
                 "templated": "true"
             },
             {
-                "rel": "http://librarysimplified.org/rel/metadata/collection-metadata-requests",
-                "href": "/{collection_metadata_identifier}/metadata_requests",
+                "rel": "http://librarysimplified.org/rel/metadata/collection-metadata-needed",
+                "href": "/{collection_metadata_identifier}/metadata_needed",
                 "title": "Get items in your collection for which the metadata wrangler needs more information to process.",
                 "templated": "true"
             },
@@ -505,7 +505,7 @@ class CatalogController(ISBNEntryMixin):
 
         return feed_response(addition_feed)
 
-    def metadata_requests_for(self, collection_details):
+    def metadata_needed_for(self, collection_details):
         """Returns identifiers in the collection that could benefit from
         distributor metadata on the circulation manager.
         """
@@ -549,7 +549,7 @@ class CatalogController(ISBNEntryMixin):
 
         title = "%s Metadata Requests for %s" % (collection.protocol, client.url)
         metadata_request_url = self.collection_feed_url(
-            'metadata_requests_for', collection
+            'metadata_needed_for', collection
         )
 
         request_feed = AcquisitionFeed(
@@ -559,7 +559,7 @@ class CatalogController(ISBNEntryMixin):
 
         self.add_pagination_links_to_feed(
             pagination, unresolved_identifiers, request_feed,
-            'metadata_requests_for', collection
+            'metadata_needed_for', collection
         )
 
         return feed_response(request_feed)

--- a/controller.py
+++ b/controller.py
@@ -74,7 +74,6 @@ HTTP_CREATED = 201
 HTTP_ACCEPTED = 202
 HTTP_UNAUTHORIZED = 401
 HTTP_NOT_FOUND = 404
-HTTP_UNPROCESSIBLE_ENTITY = 422
 HTTP_INTERNAL_SERVER_ERROR = 500
 
 OPDS_2_MEDIA_TYPE = 'application/opds+json'
@@ -544,7 +543,7 @@ class CatalogController(ISBNEntryMixin):
         messages = list()
         for identifier in feed_identifiers:
             messages.append(OPDSMessage(
-                identifier.urn, HTTP_UNPROCESSIBLE_ENTITY, "Metadata needed."
+                identifier.urn, HTTP_ACCEPTED, "Metadata needed."
             ))
 
         title = "%s Metadata Requests for %s" % (collection.protocol, client.url)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -589,7 +589,7 @@ class TestCatalogController(ControllerTest):
 
         # Only the failing identifier that doesn't have metadata submitted yet
         # is in the feed.
-        self.assert_message(m, unresolved_id, 422, 'Metadata needed.')
+        self.assert_message(m, unresolved_id, 202, 'Metadata needed.')
 
     def test_remove_items(self):
         invalid_urn = "FAKE AS I WANNA BE"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -539,7 +539,7 @@ class TestCatalogController(ControllerTest):
             invalid, 'invalid', 400, 'Could not parse identifier.'
         )
 
-    def test_metadata_requests_for(self):
+    def test_metadata_needed_for(self):
         # A regular schmegular identifier: untouched, pure.
         pure_id = self._identifier()
 
@@ -583,7 +583,7 @@ class TestCatalogController(ControllerTest):
         ])
 
         with self.app.test_request_context(headers=self.valid_auth):
-            response = self.controller.metadata_requests_for(self.collection.name)
+            response = self.controller.metadata_needed_for(self.collection.name)
 
         m = messages = self.get_messages(response.get_data())
 


### PR DESCRIPTION
This branch adds an endpoint that finds all of the identifiers in a given collection that have had trouble with resolution and returns them as a paginated feed of OPDS messages. Eventually, the circulation manager will be able to check this endpoint and send helpful data to the wrangler.

I also took the time to refactor some of the code that exists in other parts of the CatalogController around pagination and a bit of the test code.

Fixes #147.