### PR TITLE
Use consistent timestamp format

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -216,7 +216,7 @@ class TestCatalogController(ControllerTest):
 
         # A time can be passed.
         time = datetime.utcnow()
-        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ")
+        timestamp = time.strftime(self.controller.TIMESTAMP_FORMAT)
         for record in self.work1.coverage_records:
             # Set back the clock on all of work1's time records
             record.timestamp = time - timedelta(days=1)
@@ -229,7 +229,7 @@ class TestCatalogController(ControllerTest):
                 u"%s Collection Updates for %s" % (self.collection.protocol, self.client.url))
 
             # The timestamp is included in the url.
-            linkified_timestamp = time.strftime("%Y-%m-%d+%H:%M:%S").replace(":", "%3A")
+            linkified_timestamp = time.strftime(self.controller.TIMESTAMP_FORMAT).replace(":", "%3A")
             assert feed['feed']['id'].endswith(linkified_timestamp)
             # And only works updated since the timestamp are returned.
             eq_(0, len(feed['entries']))
@@ -247,7 +247,7 @@ class TestCatalogController(ControllerTest):
             eq_(identifier.urn, entry['id'])
 
         # ISBNs updated since the timestamp are also included in the feed.
-        timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        timestamp = datetime.utcnow().strftime(self.controller.TIMESTAMP_FORMAT)
         isbn = self._identifier(
             identifier_type=Identifier.ISBN, foreign_id=self._isbn
         )
@@ -323,6 +323,19 @@ class TestCatalogController(ControllerTest):
             assert any([link['rel'] == 'previous' for link in links])
             assert any([link['rel'] == 'first' for link in links])
             assert not any([link['rel'] == 'next'for link in links])
+
+    def test_updates_feed_bad_last_update_time(self):
+        """Passing in a malformed timestamp for last_update_time
+        results in a problem detail document.
+        """
+        with self.app.test_request_context(
+                '/?last_update_time=wrong format', headers=self.valid_auth
+        ):
+            response = self.controller.updates_feed(self.collection.name)
+            assert isinstance(response, ProblemDetail)
+            eq_(400, response.status_code)
+            expect_error = 'The timestamp "wrong format" is not in the expected format (%s)' % self.controller.TIMESTAMP_FORMAT
+            eq_(expect_error, response.detail)
 
     def test_add_items(self):
         invalid_urn = "FAKE AS I WANNA BE"


### PR DESCRIPTION
This branch fixes a subtle inconsistency in CatalogController.updates_feed, where the incoming timestamp was expected in a certain format, but the outgoing timestamp used in links was a slightly different format. This meant the circulation manager would successfully import the first page of the updates feed, and then the metadata wrangler would crash when the circulation manager asked for the second page.

This branch also gets rid of the crash if a bad timestamp should be sent to the metadata wrangler for whatever reason.