### PR TITLE
Set IntegrationClient provider to registered_only

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -32,7 +32,6 @@ from core.model import (
     CoverageRecord,
     DataSource,
     Edition,
-    ExternalIntegration,
     Hyperlink,
     Identifier,
     IntegrationClient,
@@ -67,7 +66,7 @@ from coverage import (
     IdentifierResolutionRegistrar,
 )
 from canonicalize import AuthorNameCanonicalizer
-from integration_client import IntegrationClientCoverageProvider
+from integration_client import IntegrationClientCoverImageCoverageProvider
 from problem_details import *
 
 HTTP_OK = 200
@@ -523,7 +522,7 @@ class CatalogController(ISBNEntryMixin):
         )
 
         # Omit identifiers that currently have metadata pending for
-        # the IntegrationClientCoverageProvider.
+        # the IntegrationClientCoverImageCoverageProvider.
         data_source = DataSource.lookup(
             self._db, collection.name, autocreate=True
         )
@@ -532,7 +531,7 @@ class CatalogController(ISBNEntryMixin):
         ).filter(
             CoverageRecord.data_source_id==data_source.id,
             CoverageRecord.status==CoverageRecord.REGISTERED,
-            CoverageRecord.operation==IntegrationClientCoverageProvider.OPERATION,
+            CoverageRecord.operation==IntegrationClientCoverImageCoverageProvider.OPERATION,
         ).subquery()
 
         unresolved_identifiers = unresolved_identifiers.outerjoin(

--- a/controller.py
+++ b/controller.py
@@ -32,6 +32,7 @@ from core.model import (
     CoverageRecord,
     DataSource,
     Edition,
+    ExternalIntegration,
     Hyperlink,
     Identifier,
     IntegrationClient,

--- a/coverage.py
+++ b/coverage.py
@@ -449,17 +449,25 @@ class IdentifierResolutionRegistrar(CatalogCoverageProvider):
             covered_collections = filter(
                 lambda c: c.protocol==provider.PROTOCOL, identifier.collections
             )
+
             if not covered_collections:
                 continue
 
-            if (provider==LookupClientCoverageProvider or
+            is_lookup_client_provider = provider==LookupClientCoverageProvider
+            if (is_lookup_client_provider or
                 not provider.COVERAGE_COUNTS_FOR_EVERY_COLLECTION
             ):
-                # The LookupClientCoverageProvider doesn't have an obvious
-                # data source. It uses the collection's data source instead.
                 for collection in covered_collections:
+                    data_source = None
+                    if is_lookup_client_provider:
+                        # The LookupClientCoverageProvider doesn't have an
+                        # obvious data source. It uses the collection's data.
+                        # source instead.
+                        data_source = collection.data_source
+
                     _record, newly_registered = provider.register(
-                        identifier, collection=collection
+                        identifier, data_source=data_source,
+                        collection=collection
                     )
             else:
                 providers.append(provider)

--- a/coverage.py
+++ b/coverage.py
@@ -62,7 +62,7 @@ from viaf import (
 )
 from integration_client import (
     CalculatesWorkPresentation,
-    IntegrationClientCoverageProvider,
+    IntegrationClientCoverImageCoverageProvider,
 )
 
 
@@ -226,7 +226,7 @@ class IdentifierResolutionCoverageProvider(CatalogCoverageProvider,
         # mirrored.
         if self.collection.protocol == ExternalIntegration.OPDS_FOR_DISTRIBUTORS:
             required.append(
-                IntegrationClientCoverageProvider(
+                IntegrationClientCoverImageCoverageProvider(
                     self.uploader, self.collection
                 )
             )
@@ -359,7 +359,7 @@ class IdentifierResolutionRegistrar(CatalogCoverageProvider):
     ]
 
     COLLECTION_PROVIDERS = [
-        IntegrationClientCoverageProvider,
+        IntegrationClientCoverImageCoverageProvider,
         LookupClientCoverageProvider,
     ]
 

--- a/integration_client.py
+++ b/integration_client.py
@@ -120,7 +120,7 @@ class CalculatesWorkPresentation(object):
         pass
 
 
-class IntegrationClientCoverageProvider(CatalogCoverageProvider,
+class IntegrationClientCoverImageCoverageProvider(CatalogCoverageProvider,
     CalculatesWorkPresentation
 ):
     """Mirrors and scales cover images we heard about from an IntegrationClient."""
@@ -137,8 +137,9 @@ class IntegrationClientCoverageProvider(CatalogCoverageProvider,
 
         # Only process identifiers that have been registered for coverage.
         kwargs['registered_only'] = kwargs.get('registered_only', True)
-        super(IntegrationClientCoverageProvider, self).__init__(
-            collection, *args, **kwargs)
+        super(IntegrationClientCoverImageCoverageProvider, self).__init__(
+            collection, *args, **kwargs
+        )
 
     @property
     def data_source(self):

--- a/integration_client.py
+++ b/integration_client.py
@@ -134,6 +134,9 @@ class IntegrationClientCoverageProvider(CatalogCoverageProvider,
 
     def __init__(self, uploader, collection, *args, **kwargs):
         self.uploader = uploader
+
+        # Only process identifiers that have been registered for coverage.
+        kwargs['registered_only'] = kwargs.get('registered_only', True)
         super(IntegrationClientCoverageProvider, self).__init__(
             collection, *args, **kwargs)
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -57,7 +57,7 @@ from coverage import (
     IdentifierResolutionCoverageProvider,
     IdentifierResolutionRegistrar,
 )
-from integration_client import IntegrationClientCoverageProvider
+from integration_client import IntegrationClientCoverImageCoverageProvider
 from problem_details import *
 
 
@@ -607,7 +607,7 @@ class TestCatalogController(ControllerTest):
         )
         self._coverage_record(
             metadata_already_id, collection_source,
-            operation=IntegrationClientCoverageProvider.OPERATION,
+            operation=IntegrationClientCoverImageCoverageProvider.OPERATION,
             status=CoverageRecord.REGISTERED,
         )
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -545,37 +545,6 @@ class TestCatalogController(ControllerTest):
             invalid, 'invalid', 400, 'Could not parse identifier.'
         )
 
-    def test_add_with_metadata_only_registers_opds_for_distributors_protocol(self):
-        # Pretend this content server OPDS came from a circulation manager.
-        base_path = os.path.split(__file__)[0]
-        resource_path = os.path.join(base_path, "files", "opds")
-        path = os.path.join(resource_path, "content_server_lookup.opds")
-        opds = open(path).read()
-
-        # Give the collection a non-OPDS-IMPORT data_source.
-        self.collection.protocol = ExternalIntegration.BIBLIOTHECA
-
-        with self.app.test_request_context(headers=self.valid_auth, data=opds):
-            response = self.controller.add_with_metadata(self.collection.name)
-
-        # The identifier in the OPDS feed is now in the catalog.
-        identifier = self._identifier(foreign_id='20201')
-        assert identifier in self.collection.catalog
-
-        # It has an edition with the appropriate metadata.
-        edition = get_one(self._db, Edition, primary_identifier=identifier)
-        eq_('Mary Gray', edition.title)
-        [author] = edition.contributors
-        eq_(Edition.UNKNOWN_AUTHOR, author.sort_name)
-        eq_("eng", edition.language)
-
-        # It isn't registered for cover mirroring.
-        cover_mirror_record = [r for r in identifier.coverage_records if (
-            r.operation == CoverageRecord.IMPORT_OPERATION and
-            r.collection == self.collection
-        )]
-        eq_([], cover_mirror_record)
-
     def test_metadata_needed_for(self):
         # A regular schmegular identifier: untouched, pure.
         pure_id = self._identifier()

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -45,7 +45,7 @@ from coverage import (
     IdentifierResolutionRegistrar,
 )
 from integration_client import (
-    IntegrationClientCoverageProvider,
+    IntegrationClientCoverImageCoverageProvider,
     WorkPresentationCoverageProvider,
 )
 from oclc_classify import (
@@ -331,7 +331,7 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
         [integration_client], [content_cafe, oclc_classify] = resolver.providers()
         assert isinstance(content_cafe, ContentCafeCoverageProvider)
         assert isinstance(oclc_classify, OCLCClassifyCoverageProvider)
-        assert isinstance(integration_client, IntegrationClientCoverageProvider)
+        assert isinstance(integration_client, IntegrationClientCoverImageCoverageProvider)
 
     def test_process_item_creates_license_pool(self):
         self.resolver.required_coverage_providers = [

--- a/tests/test_integration_client.py
+++ b/tests/test_integration_client.py
@@ -20,7 +20,7 @@ from core.testing import AlwaysSuccessfulCoverageProvider
 
 from integration_client import (
     CalculatesWorkPresentation,
-    IntegrationClientCoverageProvider,
+    IntegrationClientCoverImageCoverageProvider,
     WorkPresentationCoverageProvider,
 )
 
@@ -146,16 +146,16 @@ class TestCalculatesWorkPresentation(DatabaseTest):
         assert "Ack!" in result.exception
 
 
-class TestIntegrationClientCoverageProvider(DatabaseTest):
+class TestIntegrationClientCoverImageCoverageProvider(DatabaseTest):
 
     def setup(self):
-        super(TestIntegrationClientCoverageProvider, self).setup()
+        super(TestIntegrationClientCoverImageCoverageProvider, self).setup()
         uploader = DummyS3Uploader()
         self.collection = self._collection(
             protocol=ExternalIntegration.OPDS_FOR_DISTRIBUTORS
         )
 
-        self.provider = IntegrationClientCoverageProvider(
+        self.provider = IntegrationClientCoverImageCoverageProvider(
             uploader=uploader, collection=self.collection
         )
 


### PR DESCRIPTION
I thought IntegrationClientCoverageProvider was doing a lot more than it actually is and spent a lot of time trying to make it work across multiple DataSources (e.g. Axis360 / Bibliotheca). This isn't currently necessary, so I changed its name to `IntegrationClientCoverImageCoverageProvider` for clarity. And because `CoverImageMirror` means something else on the wrangler. (I don't love the longer class name.)

I can imagine a future when an IntegrationClientCoverageProvider is data_source specific, each with different ReplacementPolicy based on which third-party info we value above wrangler sources and which we don't. But now is not that time.