### PR TITLE
Dramatically improve the performance of remove_items on a large collection.

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -613,8 +613,10 @@ class TestCatalogController(ControllerTest):
     def test_remove_items(self):
         invalid_urn = "FAKE AS I WANNA BE"
         catalogued_id = self._identifier()
+        unaffected_id = self._identifier()
         uncatalogued_id = self._identifier()
         self.collection.catalog_identifier(catalogued_id)
+        self.collection.catalog_identifier(unaffected_id)
 
         with self.app.test_request_context(
                 '/?urn=%s&urn=%s' % (catalogued_id.urn, uncatalogued_id.urn),
@@ -644,6 +646,9 @@ class TestCatalogController(ControllerTest):
         # But it's still in the database.
         eq_(catalogued_id, self._db.query(Identifier).filter_by(
             id=catalogued_id.id).one())
+
+        # The catalog's other contents are not affected.
+        assert unaffected_id in self.collection.catalog
 
         # Try again, this time including an invalid URN.
         self.collection.catalog_identifier(catalogued_id)


### PR DESCRIPTION
This branch uses a single SELECT and a single DELETE statement to replace a number of `in` and `remove` statements which were using the database inefficiently. I don't know exactly how bad the situation is, but on a collection the size of NYPL's, that first `in` statement took up enough time all on its own to make a request time out.