### PR TITLE
Bring the fast-subset code used in remove_items to add_items

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -666,8 +666,8 @@ class CatalogController(ISBNEntryMixin):
         # Extract the identifier IDs from the dictionary.
         identifier_ids = [x.id for x in identifiers_by_urn.values()]
 
-        # Find the subset of identifiers that are in the catalog, so
-        # we know to give them a 200 message after deletion.
+        # Find the IDs for the subset of identifiers that are in the
+        # catalog.
         table = collections_identifiers.c
         identifier_match_clause = and_(
             table.identifier_id.in_(identifier_ids),

--- a/controller.py
+++ b/controller.py
@@ -416,7 +416,7 @@ class CatalogController(ISBNEntryMixin):
         # Everything else needs to be added to the catalog.
         needs_to_be_added = [
             x for x in identifiers_by_urn.values()
-            if x not in already_in_catalog
+            if x.id not in already_in_catalog
         ]
         collection.catalog_identifiers(needs_to_be_added)
 
@@ -612,13 +612,16 @@ class CatalogController(ISBNEntryMixin):
             )
             messages.append(message)
 
-        # Find the subset of identifiers that are in the catalog, so
-        # we know to give them a 200 message after deletion.
+        # Find the IDs of the subset of provided identifiers that are
+        # in the catalog, so we know which ones to delete and give a
+        # 200 message. Also get a SQLAlchemy clause that selects only
+        # those IDs.
         matching_ids, identifier_match_clause = self._in_catalog_subset(
             collection, identifiers_by_urn
         )
 
-        # Then delete all of the relevant catalog entries.
+        # Use that clause to delete all of the relevant catalog
+        # entries.
         delete_stmt = collections_identifiers.delete().where(
             identifier_match_clause
         )

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -618,6 +618,9 @@ class TestCatalogController(ControllerTest):
         self.collection.catalog_identifier(catalogued_id)
         self.collection.catalog_identifier(unaffected_id)
 
+        other_collection = self._collection()
+        other_collection.catalog_identifier(catalogued_id)
+
         with self.app.test_request_context(
                 '/?urn=%s&urn=%s' % (catalogued_id.urn, uncatalogued_id.urn),
                 method='POST', headers=self.valid_auth
@@ -649,6 +652,9 @@ class TestCatalogController(ControllerTest):
 
         # The catalog's other contents are not affected.
         assert unaffected_id in self.collection.catalog
+
+        # The other catalog was not affected.
+        assert catalogued_id in other_collection.catalog
 
         # Try again, this time including an invalid URN.
         self.collection.catalog_identifier(catalogued_id)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -455,6 +455,8 @@ class TestCatalogController(ControllerTest):
         uncatalogued_id = self._identifier()
         self.collection.catalog_identifier(catalogued_id)
 
+        other_collection = self._collection()
+
         with self.app.test_request_context(
                 '/?urn=%s&urn=%s&urn=%s' % (
                 catalogued_id.urn, uncatalogued_id.urn, invalid_urn),
@@ -479,6 +481,9 @@ class TestCatalogController(ControllerTest):
         # And even though it responds 'OK', the message tells you it
         # was already there.
         self.assert_message(m, catalogued_id, 200, 'Already in catalog')
+
+        # The other catalog is not affected.
+        eq_([], other_collection.catalog)
 
         # Invalid identifier return 400 errors.
         self.assert_message(m, invalid_urn, 400, 'Could not parse identifier.')
@@ -620,6 +625,7 @@ class TestCatalogController(ControllerTest):
 
         other_collection = self._collection()
         other_collection.catalog_identifier(catalogued_id)
+        other_collection.catalog_identifier(uncatalogued_id)
 
         with self.app.test_request_context(
                 '/?urn=%s&urn=%s' % (catalogued_id.urn, uncatalogued_id.urn),
@@ -655,6 +661,7 @@ class TestCatalogController(ControllerTest):
 
         # The other catalog was not affected.
         assert catalogued_id in other_collection.catalog
+        assert uncatalogued_id in other_collection.catalog
 
         # Try again, this time including an invalid URN.
         self.collection.catalog_identifier(catalogued_id)


### PR DESCRIPTION
This branch builds on https://github.com/NYPL-Simplified/metadata_wrangler/pull/158/ and also fixes a bug I introduced, where asking to remove an identifier from one catalog would remove it from _all_ catalogs.