### PR TITLE
Use new mirror system

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -28,9 +28,7 @@ from core.model import (
 
 from core.overdrive import OverdriveAPI
 
-from core.s3 import (
-    S3Uploader, 
-)
+from core.util.mirror import MirrorUploader
 
 from core.util import fast_query_count
 
@@ -109,8 +107,7 @@ class IdentifierResolutionCoverageProvider(CatalogCoverageProvider,
 
         # Since we are the metadata wrangler, any resources we find,
         # we mirror to S3.
-        if not uploader:
-            uploader = S3Uploader.from_config(self._db)
+        uploader = uploader or MirrorUploader.sitewide(self._db)
         self.uploader = uploader
 
         # We're going to be aggressive about recalculating the presentation

--- a/mirror.py
+++ b/mirror.py
@@ -15,7 +15,7 @@ from core.model import (
     Resource,
     Representation,
 )
-from core.s3 import S3Uploader
+from core.util.mirror import MirrorUploader
 
 
 class CoverImageMirror(object):
@@ -29,7 +29,7 @@ class CoverImageMirror(object):
     def __init__(self, db, uploader=None):
         self._db = db
         self.data_source = DataSource.lookup(self._db, self.DATA_SOURCE)
-        self.uploader = uploader or S3Uploader.from_config(self._db)
+        self.uploader = uploader or MirrorUploader.sitewide(self._db)
         self.log = logging.getLogger("Cover Image Mirror")
 
     def run(self):
@@ -123,7 +123,7 @@ class ImageScaler(object):
     def __init__(self, db, mirrors, uploader=None):
         self._db = db
         self.data_source_ids = []
-        self.uploader = uploader or S3Uploader.from_config(self._db)
+        self.uploader = uploader or MirrorUploader.sitewide(self._db)
         self.log = logging.getLogger("Cover Image Scaler")
 
         for mirror in mirrors:

--- a/overdrive.py
+++ b/overdrive.py
@@ -7,7 +7,7 @@ from core.metadata_layer import ReplacementPolicy
 from core.overdrive import (
     OverdriveBibliographicCoverageProvider as BaseOverdriveBibliographicCoverageProvider
 )
-from core.s3 import S3Uploader
+from core.util.mirror import MirrorUploader
 
 from mirror import CoverImageMirror
 
@@ -19,7 +19,10 @@ class OverdriveBibliographicCoverageProvider(
 
     def __init__(self, collection, uploader=None, **kwargs):
         _db = Session.object_session(collection)
-        self.mirror = uploader or S3Uploader.from_config(_db)
+        # As the metadata wrangler, we will be mirroring these to the
+        # sitewide mirror rather than to a mirror associated
+        # with a specific collection.
+        self.mirror = uploader or MirrorUploader.sitewide(collection)
         kwargs['registered_only'] = True
         super(OverdriveBibliographicCoverageProvider, self).__init__(
             collection, **kwargs

--- a/tests/test_content_cafe.py
+++ b/tests/test_content_cafe.py
@@ -7,7 +7,7 @@ from nose.tools import (
 from core.config import CannotLoadConfiguration
 from core.coverage import CoverageFailure
 from core.model import ExternalIntegration
-from core.s3 import DummyS3Uploader
+from core.s3 import MockS3Uploader
 
 from . import (
     DatabaseTest,
@@ -52,7 +52,7 @@ class TestContentCafeAPI(DatabaseTest):
 
         integration.username = u'yup'
         result = ContentCafeAPI.from_config(
-            self._db, None, uploader=DummyS3Uploader(),
+            self._db, None, uploader=MockS3Uploader(),
             soap_client=DummyContentCafeSOAPClient()
         )
         eq_(True, isinstance(result, ContentCafeAPI))
@@ -62,7 +62,7 @@ class TestContentCafeCoverageProvider(DatabaseTest):
 
     def test_constructor(self):
         """Just test that we can create the object."""
-        uploader=DummyS3Uploader()
+        uploader=MockS3Uploader()
         soap_client = DummyContentCafeSOAPClient()
         api = ContentCafeAPI(self._db, None, "user_id", "password", 
                              uploader, soap_client=soap_client)
@@ -78,7 +78,7 @@ class TestContentCafeCoverageProvider(DatabaseTest):
                 raise Exception("Oh no!")
 
         provider = ContentCafeCoverageProvider(
-            self._db, api=AlwaysFailsContentCafe(), uploader=DummyS3Uploader()
+            self._db, api=AlwaysFailsContentCafe(), uploader=MockS3Uploader()
         )
         identifier = self._identifier()
         result = provider.process_item(identifier)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -28,7 +28,7 @@ from core.overdrive import (
     MockOverdriveAPI,
     OverdriveBibliographicCoverageProvider,
 )
-from core.s3 import DummyS3Uploader
+from core.s3 import MockS3Uploader
 from core.testing import (
     AlwaysSuccessfulCoverageProvider,
     NeverSuccessfulCoverageProvider,
@@ -208,7 +208,7 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
             IdentifierResolutionCoverageProvider.DEFAULT_OVERDRIVE_COLLECTION_NAME
         )
         self.viaf = MockVIAFClient(self._db)
-        self.uploader = DummyS3Uploader()
+        self.uploader = MockS3Uploader()
         self.mock_content_cafe = ContentCafeAPI(
             self._db, None, object(), object(), self.uploader
         )

--- a/tests/test_integration_client.py
+++ b/tests/test_integration_client.py
@@ -15,7 +15,7 @@ from core.model import (
     PresentationCalculationPolicy,
     Work,
 )
-from core.s3 import DummyS3Uploader
+from core.s3 import MockS3Uploader
 from core.testing import AlwaysSuccessfulCoverageProvider
 
 from integration_client import (
@@ -150,7 +150,7 @@ class TestIntegrationClientCoverImageCoverageProvider(DatabaseTest):
 
     def setup(self):
         super(TestIntegrationClientCoverImageCoverageProvider, self).setup()
-        uploader = DummyS3Uploader()
+        uploader = MockS3Uploader()
         self.collection = self._collection(
             protocol=ExternalIntegration.OPDS_FOR_DISTRIBUTORS
         )

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -3,7 +3,7 @@ from nose.tools import (
     eq_,
     set_trace,
 )
-from core.s3 import DummyS3Uploader
+from core.s3 import MockS3Uploader
 from core.testing import (
     DatabaseTest,
     DummyHTTPClient,
@@ -23,7 +23,7 @@ class TestOverdriveBibliographicCoverageProvider(DatabaseTest):
 
     def test_replacement_policy_uses_provided_mirror(self):
         collection = MockOverdriveAPI.mock_collection(self._db)
-        mirror = DummyS3Uploader()
+        mirror = MockS3Uploader()
         provider = OverdriveBibliographicCoverageProvider(
                 collection, uploader=mirror, api_class=MockOverdriveAPI
         )


### PR DESCRIPTION
This branch updates the metadata wrangler to use the mirror system established in https://github.com/NYPL-Simplified/server_core/pull/787.

For the metadata wrangler it's pretty simple because we still have a single site-wide mirror system which is used in every situation. The only difference is that system is instantiated through `MirrorUploader.sitewide` (allowing for the possibility that the mirror might use something other than S3) and the `DummyS3Uploader` class has been renamed to `MockS3Uploader`.