### PR TITLE
Threaded coverage #129

### DIFF
--- a/bin/identifiers_resolve
+++ b/bin/identifiers_resolve
@@ -6,7 +6,7 @@ bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
 
-from core.scripts import RunCollectionCoverageProviderScript
+from core.scripts import RunThreadedCollectionCoverageProviderScript
 from coverage import IdentifierResolutionCoverageProvider
 
-RunCollectionCoverageProviderScript(IdentifierResolutionCoverageProvider).run()
+RunThreadedCollectionCoverageProviderScript(IdentifierResolutionCoverageProvider).run()

--- a/coverage.py
+++ b/coverage.py
@@ -28,7 +28,7 @@ from core.model import (
 
 from core.overdrive import OverdriveAPI
 
-from core.util.mirror import MirrorUploader
+from core.mirror import MirrorUploader
 
 from core.util import fast_query_count
 

--- a/coverage.py
+++ b/coverage.py
@@ -153,23 +153,19 @@ class IdentifierResolutionCoverageProvider(CatalogCoverageProvider,
         )
 
     @classmethod
-    def all(cls, _db, **kwargs):
-        """Yield a sequence of IdentifierResolutionCoverageProvider instances,
-        one for every collection.
-
-        The 'unaffiliated' collection is always last in the list.
+    def collections(cls, _db):
+        """Return a list of covered collections. The 'unaffiliated' collection
+        is always last in the list.
         """
         unaffiliated, ignore = cls.unaffiliated_collection(_db)
-        instances = list(super(IdentifierResolutionCoverageProvider, cls).all(
-            _db, **kwargs
-        ))
-        collections = [x.collection for x in instances]
-        if unaffiliated in collections:
-            i = collections.index(unaffiliated)
-            unaffiliated_instance = instances[i]
-            instances.remove(unaffiliated_instance)
-            instances.append(unaffiliated_instance)
-        return instances
+        collections = super(cls, cls).collections(_db)
+
+        if unaffiliated in collections[:]:
+            # Always put the unaffiliated collection last.
+            collections.remove(unaffiliated)
+            collections.append(unaffiliated)
+
+        return collections
 
     def providers(self):
         """Instantiate required and optional CoverageProviders.

--- a/mirror.py
+++ b/mirror.py
@@ -15,7 +15,7 @@ from core.model import (
     Resource,
     Representation,
 )
-from core.util.mirror import MirrorUploader
+from core.mirror import MirrorUploader
 
 
 class CoverImageMirror(object):

--- a/overdrive.py
+++ b/overdrive.py
@@ -7,7 +7,7 @@ from core.metadata_layer import ReplacementPolicy
 from core.overdrive import (
     OverdriveBibliographicCoverageProvider as BaseOverdriveBibliographicCoverageProvider
 )
-from core.util.mirror import MirrorUploader
+from core.mirror import MirrorUploader
 
 from mirror import CoverImageMirror
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ mock
 cairosvg==1.0.22
 Flask-Babel
 money
+pymarc
 
 # Ensure that we support SNI-based SSL
 ndg-httpsclient

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -261,6 +261,7 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
             self._db, uploader=self.uploader, 
             content_cafe_api=self.mock_content_cafe,
         )
+        providers = list(providers)
         eq_(6, len(providers))
         eq_(unaffiliated, providers[-1].collection)
 


### PR DESCRIPTION
This branch uses threads from NYPL-Simplified/server_core#811 to fix #129. Tests with a relatively small set of 200 identifiers showed a 2.5x processing improvement.