### PR TITLE
Add docker

### DIFF
--- a/bin/initialize_instance
+++ b/bin/initialize_instance
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Resolve all unresolved identifiers."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from scripts import InstanceInitializationScript
+InstanceInitializationScript().run()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.6'
+services:
+  db:
+    image: "postgres:9.5"
+    environment:
+      POSTGRES_PASSWORD: "password"
+      POSTGRES_USER: "simplified"
+      POSTGRES_DB: "simplified_metadata_dev"
+    volumes:
+      - "dbdata:/var/lib/postgresql/data"
+
+  webapp:
+    build:
+      context: docker/
+      dockerfile: Dockerfile.webapp
+      args:
+        - version
+    environment:
+      SIMPLIFIED_PRODUCTION_DATABASE: postgres://simplified:password@db:5432/simplified_metadata_dev
+    ports:
+      - 80:80
+    depends_on:
+      - db
+    volumes:
+      - "uwsgi_log:/var/log/uwsgi"
+
+  scripts:
+    build:
+      context: docker/
+      dockerfile: Dockerfile.scripts
+      args:
+        - version
+    environment:
+      SIMPLIFIED_PRODUCTION_DATABASE: postgres://simplified:password@db:5432/simplified_metadata_dev
+    depends_on:
+      - db
+    volumes:
+      - "script_logs:/var/log/simplified"
+
+volumes:
+  dbdata:
+  uwsgi_log:
+  script_logs:

--- a/docker/Dockerfile.exec
+++ b/docker/Dockerfile.exec
@@ -1,0 +1,22 @@
+FROM phusion/baseimage
+MAINTAINER Library Simplified <info@librarysimplified.org>
+
+ARG version
+ARG repo="NYPL-Simplified/metadata_wrangler"
+
+ENV SIMPLIFIED_DB_TASK "auto"
+ENV SIMPLIFIED_SCRIPT_NAME ""
+
+# Copy over all Library Simplified build files for this image
+COPY . /ls_build
+
+RUN /bin/bash -c "/ls_build/simplified_app.sh ${repo} ${version} \
+      && /ls_build/logrotate.sh \
+      && rm -rf /ls_build && /bd_build/cleanup.sh"
+
+VOLUME /var/log
+WORKDIR /home/simplified/metadata/bin
+
+CMD ["/sbin/my_init", "--skip-runit", "--quiet", "--", \
+     "/bin/bash", "-c", \
+     "source ../env/bin/activate && ./${SIMPLIFIED_SCRIPT_NAME}"]

--- a/docker/Dockerfile.scripts
+++ b/docker/Dockerfile.scripts
@@ -1,0 +1,22 @@
+FROM phusion/baseimage
+MAINTAINER Library Simplified <info@librarysimplified.org>
+
+ARG version
+ARG repo="NYPL-Simplified/metadata_wrangler"
+
+ENV SIMPLIFIED_DB_TASK "auto"
+
+ENV TZ=US/Eastern
+
+# Copy over all Library Simplified build files for this image
+COPY . /ls_build
+
+RUN /bin/bash -c "/ls_build/simplified_app.sh ${repo} ${version} \
+      && /ls_build/logrotate.sh \
+      && /ls_build/simplified_cron.sh \
+      && rm -rf /ls_build && /bd_build/cleanup.sh"
+
+VOLUME /var/log
+WORKDIR /home/simplified/metadata/bin
+
+CMD ["/sbin/my_init"]

--- a/docker/Dockerfile.webapp
+++ b/docker/Dockerfile.webapp
@@ -1,0 +1,26 @@
+FROM phusion/baseimage
+MAINTAINER Library Simplified <info@librarysimplified.org>
+
+ARG version
+ARG repo="NYPL-Simplified/metadata_wrangler"
+
+ENV SIMPLIFIED_DB_TASK "auto"
+
+# Copy over all Library Simplified build files for this image
+COPY . /ls_build
+
+RUN /bin/bash -c "/ls_build/simplified_app.sh ${repo} ${version} \
+      && /ls_build/nginx.sh \
+      && /ls_build/uwsgi.sh \
+      && /ls_build/logrotate.sh \
+      && rm -rf /ls_build && /bd_build/cleanup.sh"
+
+VOLUME /var/log
+WORKDIR /home/simplified/metadata
+EXPOSE 80
+
+CMD ["/sbin/my_init"]
+
+# # If you launch the container interactively with `docker run -it`,
+# # this is where you'll end up:
+# ENTRYPOINT ["/bin/bash"]

--- a/docker/logrotate.sh
+++ b/docker/logrotate.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+
+# Add logrotate configuration files
+cp /ls_build/services/logrotate.conf /etc/
+cp /ls_build/services/default_logrotate /etc/logrotate.d/
+cp /ls_build/services/simplified_logrotate.conf /etc/logrotate.d/simplified.conf
+
+chmod 644 /etc/logrotate.conf \
+  /etc/logrotate.d/default_logrotate \
+  /etc/logrotate.d/simplified.conf
+
+# Remove logrotate for dpkg as we will do
+# our own in the default_logrotate.
+rm -rf /etc/logrotate.d/dpkg

--- a/docker/nginx.sh
+++ b/docker/nginx.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+source /bd_build/buildconfig
+set -x
+
+$minimal_apt_get_install nginx
+
+# Configure nginx.
+rm /etc/nginx/sites-enabled/default
+cp /ls_build/services/nginx.conf /etc/nginx/conf.d/metadata.conf
+echo "daemon off;" >> /etc/nginx/nginx.conf
+
+# Prepare nginx for runit.
+mkdir /etc/service/nginx
+cp /ls_build/services/nginx.runit /etc/service/nginx/run

--- a/docker/services/default_logrotate
+++ b/docker/services/default_logrotate
@@ -1,0 +1,67 @@
+# Setup log-rotate to rotate logs in /var/log
+# on a weekly basis for 13 weeks/3mo.
+#
+# Grab all logs in /var/log, exclude alternatives.log, this is handled by apt logrotate file in /etc/logrotate.d/
+/var/log/*.log {
+    weekly
+    missingok
+    rotate 13
+    copytruncate
+    compress
+    delaycompress
+    notifempty
+    dateext
+    create 0700 root root
+    }
+
+# FSCK Logs
+/var/log/fsck/*.log {
+    weekly
+    missingok
+    rotate 13
+    copytruncate
+    compress
+    delaycompress
+    notifempty
+    dateext
+    create 0700 root root
+    }
+
+# DMESG Log
+/var/log/dmesg {
+    weekly
+    missingok
+    rotate 13
+    copytruncate
+    compress
+    delaycompress
+    notifempty
+    dateext
+    create 0700 root root
+    }
+
+# FAILLOG log
+/var/log/faillog {
+    weekly
+    missingok
+    rotate 13
+    copytruncate
+    compress
+    delaycompress
+    notifempty
+    dateext
+    create 0700 root root
+    }
+
+# LASTLOG log
+/var/log/lastlog {
+    weekly
+    missingok
+    rotate 13
+    copytruncate
+    compress
+    delaycompress
+    notifempty
+    dateext
+    create 0700 root root
+    }

--- a/docker/services/logrotate.conf
+++ b/docker/services/logrotate.conf
@@ -1,0 +1,67 @@
+# Setup log-rotate to rotate logs in /var/log
+# on a weekly basis for 13 weeks/3mo.
+#
+# Grab all logs in /var/log, exclude alternatives.log, this is handled by apt logrotate file in /etc/logrotate.d/
+/var/log/*.log {
+    weekly
+    missingok
+    rotate 13
+    copytruncate
+    compress
+    delaycompress
+    notifempty
+    dateext
+    create 0700 root root
+    }
+
+# FSCK Logs
+/var/log/fsck/*.log {
+    weekly
+    missingok
+    rotate 13
+    copytruncate
+    compress
+    delaycompress
+    notifempty
+    dateext
+    create 0700 root root
+    }
+
+# DMESG Log
+/var/log/dmesg {
+    weekly
+    missingok
+    rotate 13
+    copytruncate
+    compress
+    delaycompress
+    notifempty
+    dateext
+    create 0700 root root
+    }
+
+# FAILLOG log
+/var/log/faillog {
+    weekly
+    missingok
+    rotate 13
+    copytruncate
+    compress
+    delaycompress
+    notifempty
+    dateext
+    create 0700 root root
+    }
+
+# LASTLOG log
+/var/log/lastlog {
+    weekly
+    missingok
+    rotate 13
+    copytruncate
+    compress
+    delaycompress
+    notifempty
+    dateext
+    create 0700 root root
+    }

--- a/docker/services/nginx.conf
+++ b/docker/services/nginx.conf
@@ -1,0 +1,14 @@
+server {
+    listen      80 deferred;
+    server_name localhost;
+    charset     utf-8;
+    client_max_body_size 75M;
+    merge_slashes off;
+
+    location / { try_files $uri @metadata; }
+    location @metadata {
+        include uwsgi_params;
+        uwsgi_read_timeout 120;
+        uwsgi_pass unix:/var/www/metadata/uwsgi.sock;
+    }
+}

--- a/docker/services/nginx.runit
+++ b/docker/services/nginx.runit
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+exec /usr/sbin/nginx

--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -1,0 +1,27 @@
+# /etc/cron.d/circulation: Library Simplified Circulation Manager crontab
+# You don't have to run the `crontab' command to install the new
+# version when you edit this file in /etc/cron.d. Files in this directory
+# also have username fields, similar to the systemwide /etc/crontab.
+
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+HOME=/var/www/circulation
+
+# m h dom mon dow user command
+
+# Register identifiers to for coverage from all third-party sources.
+*/30 * * * * root core/bin/run register_identifiers >> /var/log/cron.log 2>&1
+
+# Confirm complete overall coverage and generate Works.
+8 * * * * root core/bin/run identifiers_resolve >> /var/log/cron.log 2>&1
+
+# Coverage from third-party data sources
+#
+51 */2 * * * root core/bin/run content_cafe_coverage >> /var/log/cron.log 2>&1
+23 */6 * * * root core/bin/run integration_client_coverage >> /var/log/cron.log 
+0 */3 * * * root core/bin/run oclc_classify_coverage >> /var/log/cron.log 2>&1
+12 */2 * * * root core/bin/run oclc_linked_data_coverage >> /var/log/cron.log 2>&1
+31 */6 * * * root core/bin/run opds_import_coverage >> /var/log/cron.log 2>&1
+42 */4 * * * root core/bin/run overdrive_bibliographic_coverage >> /var/log/cron.log 2>&1
+0 0 * * * root core/bin/run subjects_assign >> /var/log/cron.log 2>&1
+45 */12 * * * root core/bin/run work_presentation_coverage >> /var/log/cron.log 2>&1

--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -1,11 +1,11 @@
-# /etc/cron.d/circulation: Library Simplified Circulation Manager crontab
+# /etc/cron.d/metadata: Library Simplified Metadata Wrangler crontab
 # You don't have to run the `crontab' command to install the new
 # version when you edit this file in /etc/cron.d. Files in this directory
 # also have username fields, similar to the systemwide /etc/crontab.
 
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-HOME=/var/www/circulation
+HOME=/var/www/metadata
 
 # m h dom mon dow user command
 

--- a/docker/services/simplified_logrotate.conf
+++ b/docker/services/simplified_logrotate.conf
@@ -1,0 +1,11 @@
+/var/log/simplified/* {
+    missingok
+    daily
+    create 0700 root root
+    rotate 13
+    copytruncate
+    compress
+    delaycompress
+    notifempty
+    dateext
+}

--- a/docker/services/simplified_user.runit
+++ b/docker/services/simplified_user.runit
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+exec chpst -u simplified runsvdir /home/simplified/service

--- a/docker/services/uwsgi.ini
+++ b/docker/services/uwsgi.ini
@@ -1,0 +1,24 @@
+[uwsgi]
+# application's base folder
+base = /var/www/metadata
+home = %(base)/env
+pythonpath = %(base)
+
+# python module to import
+module = app
+callable = app
+
+# location and permissions of socket file
+socket = /var/www/metadata/%n.sock
+chmod-socket = 666
+
+# location of log files
+logto = /var/log/uwsgi/%n.log
+log-format = %(addr) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)
+
+processes = 6
+threads = 2
+harakiri = 300
+lazy-apps = true
+touch-reload = %(base)/uwsgi.ini
+buffer-size = 131072

--- a/docker/services/uwsgi.runit
+++ b/docker/services/uwsgi.runit
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+source ~/metadata/env/bin/activate && uwsgi --ini ~/metadata/uwsgi.ini

--- a/docker/simplified_app.sh
+++ b/docker/simplified_app.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+source /bd_build/buildconfig
+set -x
+
+repo="$1"
+version="$2"
+
+apt-get update && $minimal_apt_get_install python-dev \
+  python2.7 \
+  python-cairo \
+  python-nose \
+  python-pip \
+  gcc \
+  git \
+  libpcre3 \
+  libpcre3-dev \
+  libffi-dev \
+  libjpeg-dev \
+
+# Create a user.
+useradd -ms /bin/bash -U simplified
+
+# Get the proper version of the codebase.
+mkdir /var/www && cd /var/www
+git clone https://github.com/${repo}.git metadata
+chown simplified:simplified metadata 
+cd metadata
+git checkout $version
+
+# Use https to access submodules.
+git config submodule.core.url https://github.com/NYPL-Simplified/server_core.git
+git submodule update --init --recursive
+
+# Add a .version file to the directory. This file
+# supplies an endpoint to check the app's current version.
+printf "$(git describe --tags)" > .version
+
+# Use the latest version of pip to install a virtual environment for the app.
+pip install -U --no-cache-dir pip setuptools
+pip install --no-cache-dir virtualenv virtualenvwrapper
+virtualenv -p /usr/bin/python2.7 env
+
+# Pass runtime environment variables to the app at runtime.
+touch environment.sh
+SIMPLIFIED_ENVIRONMENT=/var/www/metadata/environment.sh
+echo "if [[ -f $SIMPLIFIED_ENVIRONMENT ]]; then \
+      source $SIMPLIFIED_ENVIRONMENT; fi" >> env/bin/activate
+
+# Install required python libraries.
+set +x && source env/bin/activate && set -x
+pip install -r requirements.txt
+
+# Install NLTK.
+python -m textblob.download_corpora
+mv /root/nltk_data /usr/lib/
+
+# Link the repository code to /home/simplified and change permissions
+su - simplified -c "ln -s /var/www/metadata /home/simplified/metadata"
+chown -RHh simplified:simplified /home/simplified/metadata
+
+# Give logs a place to go.
+mkdir /var/log/simplified
+
+# Copy scripts that run at startup.
+cp /ls_build/startup/* /etc/my_init.d/

--- a/docker/simplified_cron.sh
+++ b/docker/simplified_cron.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Switch to local timezone
+ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
+
+# Create cron tasks & logfile
+cp /ls_build/services/simplified_crontab /etc/cron.d/metadata
+touch /var/log/cron.log

--- a/docker/startup/01_set_simplified_environment.sh
+++ b/docker/startup/01_set_simplified_environment.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Stores Circulation Manager environment variables in the virtualenv environment.
+# Stores Metadata Wrangler environment variables in the virtualenv environment.
 # Local environment variables are not passed into cron, so variables set at
 # runtime need to be stored.
 

--- a/docker/startup/01_set_simplified_environment.sh
+++ b/docker/startup/01_set_simplified_environment.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Stores Circulation Manager environment variables in the virtualenv environment.
+# Local environment variables are not passed into cron, so variables set at
+# runtime need to be stored.
+
+set -ex
+
+SIMPLIFIED_ENVIRONMENT=/var/www/metadata/environment.sh
+
+# Make sure there's a file to put environment variables into
+touch $SIMPLIFIED_ENVIRONMENT
+
+# Move all of the environment variables with Library Simplified prefixes
+# into an environment file. This will allow the environment to be loaded when
+# cron tasks are run, since crontab doesn't load them automatically.
+printenv | \
+  grep -e SIMPLIFIED -e LIBSIMPLE | \
+  sed 's/^\(.*\)$/export \1/g' | \
+  cat > $SIMPLIFIED_ENVIRONMENT
+
+# Give it to the appropriate user.
+chown simplified:simplified $SIMPLIFIED_ENVIRONMENT

--- a/docker/startup/02_manage_simplified_database.sh
+++ b/docker/startup/02_manage_simplified_database.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Manages the Circulation Manager database (either initializing it, migrating
+# it, or ignoring it) when the container starts and before the app launches.
+
+set -ex
+
+WORKDIR=/var/www/metadata
+BINDIR=$WORKDIR/bin
+CORE_BINDIR=$WORKDIR/core/bin
+
+initialization_task="${BINDIR}/initialize_instance"
+migration_task="${CORE_BINDIR}/migrate_database"
+
+su simplified <<EOF
+# Default value 'ignore' does nothing.
+if ! [[ $SIMPLIFIED_DB_TASK == "ignore" ]]; then
+
+  # Enter the virtual environment for the application.
+  source $WORKDIR/env/bin/activate;
+
+  if [[ $SIMPLIFIED_DB_TASK == "auto" ]] && [[ -f ${initialization_task} ]] \
+      && [[ -f ${migration_task} ]]; then
+    # Use 'auto' to initialize the database and then migrate it -- accounting
+    # for either starting off an untouched database or keeping an existing one
+    # up to date. This option is great for automated deployment.
+    ${initialization_task} && ${migration_task};
+
+  elif [[ $SIMPLIFIED_DB_TASK == "init" ]] && [[ -f ${initialization_task} ]]; then
+    # Initialize the database with value 'init'
+    ${initialization_task};
+
+  elif [[ $SIMPLIFIED_DB_TASK == "migrate" ]] && [[ -f ${migration_task} ]]; then
+    # Migrate the database with value 'migrate'
+    ${migration_task};
+
+  # Raise an error if any other value is sent
+  else echo "Unknown database task '${SIMPLIFIED_DB_TASK}' requested" && exit 127;
+  fi;
+
+fi;
+EOF

--- a/docker/startup/02_manage_simplified_database.sh
+++ b/docker/startup/02_manage_simplified_database.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Manages the Circulation Manager database (either initializing it, migrating
+# Manages the Metadata Wrangler database (either initializing it, migrating
 # it, or ignoring it) when the container starts and before the app launches.
 
 set -ex

--- a/docker/uwsgi.sh
+++ b/docker/uwsgi.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -ex
+
+# Configure uwsgi.
+cp /ls_build/services/uwsgi.ini /var/www/metadata/uwsgi.ini
+chown simplified:simplified /var/www/metadata/uwsgi.ini
+mkdir /var/log/uwsgi
+chown -R simplified:simplified /var/log/uwsgi
+
+# Defer uwsgi service to simplified.
+mkdir /etc/service/runsvdir-simplified
+cp /ls_build/services/simplified_user.runit /etc/service/runsvdir-simplified/run
+
+# Prepare uwsgi for runit.
+app_home=/home/simplified
+mkdir -p $app_home/service/uwsgi
+cp /ls_build/services/uwsgi.runit $app_home/service/uwsgi/run
+chown -R simplified:simplified $app_home/service
+
+# Create an alias to restart the application.
+touch $app_home/.bash_aliases
+echo "alias restart_app=\`touch ~/metadata/uwsgi.ini\`" >> $app_home/.bash_aliases
+chown -R simplified:simplified $app_home/.bash_aliases


### PR DESCRIPTION
Dockerize the metadata wrangler, including support for docker-compose.

Most of these changes are nearly identical to NYPL-Simplified/circulation-docker, with a few key differences that keep things moving:
  - the name of the database and application directory created (though this is largely cosmetic)
  - the addition of node/npm in `simplified_app.sh` (apt-get and api installation)
  - the app module in `uwsgi.ini`
  - the scripts in `docker/services/simplified_crontab`

I hate the amount of duplication -- which ensures that changes beneficial to `circulation-docker` won't make their way here -- but I don't have time to fix it at the moment.

There's also this annoying thing where you can set `depends_on` in `docker-compose`, but it doesn't actually make sure the supporting container enters a "ready" state before it starts the dependent container. There's more info on how to fix it here: https://docs.docker.com/compose/startup-order/.

So with the database and two dependent containers competing to initialize it, you must run `docker-compose up` three times to get both applications to start. The first time, the database is created while the application containers error out. The second time, the database is initialized by one container while the other errors out. The third time -- now fully initialized -- all three containers begin.