### PR TITLE
Prevent timeouts by making the lookup controller take at most 10 items at once.

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -829,8 +829,11 @@ class URNLookupController(CoreURNLookupController, ISBNEntryMixin):
     def process_urns(self, urns, collection_details=None, **kwargs):
         """Processes URNs submitted via lookup request
 
-        An authenticated request can process up to 50 URNs at once,
-        but must specify a collection under which to catalog the URNs.
+        An authenticated request can process up to 10 URNs at once,
+        but must specify a collection under which to catalog the
+        URNs. This is generally not necessary -- URNs should be
+        registered and updates on them should be obtained using the
+        CatalogController.
 
         An unauthenticated request is used for testing. Such a request
         does not have to specify a collection (the "Unaffiliated"
@@ -850,7 +853,7 @@ class URNLookupController(CoreURNLookupController, ISBNEntryMixin):
             # Authenticated access.
             if not collection:
                 return INVALID_INPUT.detailed(_("No collection provided."))
-            limit = 50
+            limit = 10
         else:
             # Anonymous access.
             collection = self.default_collection

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -904,9 +904,9 @@ class TestURNLookupController(ControllerTest):
         eq_(u"No collection provided.", result.detail)
 
         # Failure - we sent too many URNs.
-        result = self.controller.process_urns([urn] * 51, collection_details=name)
+        result = self.controller.process_urns([urn] * 11, collection_details=name)
         eq_(INVALID_INPUT.uri, result.uri)
-        eq_(u"The maximum number of URNs you can provide at once is 50. (You sent 51)",
+        eq_(u"The maximum number of URNs you can provide at once is 10. (You sent 11)",
             result.detail)
 
 


### PR DESCRIPTION
We've got an un-upgraded server which is periodically bringing down the metadata wrangler with its large lookup requests. This branch rejects those requests before they have a chance to bring down the server, without totally disabling the `/lookup` endpoint.