### PR TITLE
A client can re-register with the metadata wrangler without knowing the shared secret, by signing a JWT with its private key.

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -869,10 +869,11 @@ class URNLookupController(CoreURNLookupController, ISBNEntryMixin):
     def process_urns(self, urns, collection_details=None, **kwargs):
         """Processes URNs submitted via lookup request
 
-        An authenticated request can process up to 10 URNs at once,
+        An authenticated request can process up to 30 URNs at once,
         but must specify a collection under which to catalog the
-        URNs. This is generally not necessary -- URNs should be
-        registered and updates on them should be obtained using the
+        URNs. This is used when initially recording the fact that
+        certain URNs are in a collection, to get a baseline set of
+        metadata. Updates on the books should be obtained through the
         CatalogController.
 
         An unauthenticated request is used for testing. Such a request
@@ -880,6 +881,7 @@ class URNLookupController(CoreURNLookupController, ISBNEntryMixin):
         collection is used), but can only process one URN at a time.
 
         :return: None or ProblemDetail
+
         """
         client = authenticated_client_from_request(self._db, required=False)
         if isinstance(client, ProblemDetail):
@@ -893,7 +895,7 @@ class URNLookupController(CoreURNLookupController, ISBNEntryMixin):
             # Authenticated access.
             if not collection:
                 return INVALID_INPUT.detailed(_("No collection provided."))
-            limit = 10
+            limit = 30
         else:
             # Anonymous access.
             collection = self.default_collection

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ pyld
 beautifulsoup4
 suds
 py-bcrypt
+pyjwt==1.4.2
 
 # for author name matching
 nameparser

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -997,9 +997,9 @@ class TestURNLookupController(ControllerTest):
         eq_(u"No collection provided.", result.detail)
 
         # Failure - we sent too many URNs.
-        result = self.controller.process_urns([urn] * 11, collection_details=name)
+        result = self.controller.process_urns([urn] * 31, collection_details=name)
         eq_(INVALID_INPUT.uri, result.uri)
-        eq_(u"The maximum number of URNs you can provide at once is 10. (You sent 11)",
+        eq_(u"The maximum number of URNs you can provide at once is 30. (You sent 31)",
             result.detail)
 
 


### PR DESCRIPTION
This fixes the metadata side of https://jira.nypl.org/browse/SIM-84.