### PR TITLE
Don't even parse URNs for identifier types we can't resolve.

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1092,28 +1092,22 @@ class TestURNLookupController(ControllerTest):
 
     @basic_request_context
     def test_process_identifier_unresolvable_type(self):
-        # We can't resolve a 3M identifier because we don't have the
+        # We can't resolve a Bibliotheca identifier because we don't have the
         # appropriate access to the bibliographic API.
-        identifier = self._identifier(Identifier.THREEM_ID)
+        identifier = self._identifier(Identifier.BIBLIOTHECA_ID)
         self.controller.process_identifier(identifier, identifier.urn)
         self.assert_one_message(
             identifier.urn, HTTP_NOT_FOUND, self.controller.UNRESOLVABLE_IDENTIFIER
         )
 
     @basic_request_context
-    def test_presentation_ready_work_overrides_unresolveable_type(self):
-        # If there is a presentation-ready Work associated
-        # with the identifier, turns out we can resolve it even if the
-        # type would otherwise not be resolvable.
-        edition, pool = self._edition(
-            identifier_type=Identifier.THREEM_ID, with_license_pool=True
-        )
-        pool.open_access = False
-        work, is_new = pool.calculate_work()
-        work.presentation_ready = True
-        identifier = edition.primary_identifier
-        self.controller.process_identifier(identifier, identifier.urn)
-        eq_([(identifier, work)], self.controller.works)
+    def test_process_urns_unresolvable_type(self):
+        # We won't even parse a Bibliotheca identifier because we
+        # know we can't resolve it.
+        identifier = self._identifier(Identifier.BIBLIOTHECA_ID)
+        response = self.controller.process_urns([identifier.urn])
+        [message] = self.controller.precomposed_entries
+        eq_("Could not parse identifier.", message.message)
 
     @basic_request_context
     def test_process_identifier_isbn(self):


### PR DESCRIPTION
The metadata wrangler is cluttered with identifiers of types we can't actually resolve. Circulation managers are supposed to only send identifiers that can be resolved, but it happens anyway. This branch makes the metadata wrangler simply refuse to deal with identifiers that can't be resolved. They won't even make it to the database.