### PR TITLE
If there is no BASE_URL configured, the ID of the OPDS catalog document is the URL used to request it.

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -120,7 +120,7 @@ class IndexController(object):
         self._db = _db
 
     def opds_catalog(self):
-        url = ConfigurationSetting.sitewide(self._db, Configuration.BASE_URL_KEY).value
+        url = ConfigurationSetting.sitewide(self._db, Configuration.BASE_URL_KEY).value_or_default(request.url)
         catalog = dict(
             id=url,
             title='Library Simplified Metadata Wrangler',


### PR DESCRIPTION
This branch fixes a problem where the OPDS catalog document of a brand new metadata wrangler would have `id: null` because the server didn't have its BASE_URL configured. Now the default `id` is the URL that was used to request the catalog document, which is good enough for local usage.