### PR TITLE
Content cafe is a collection coverage provider now

### DIFF
--- a/bin/content_cafe_coverage
+++ b/bin/content_cafe_coverage
@@ -7,6 +7,6 @@ package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
 
 from content_cafe import ContentCafeCoverageProvider
-from core.scripts import RunCoverageProviderScript
+from core.scripts import RunCollectionCoverageProviderScript
 
-RunCoverageProviderScript(ContentCafeCoverageProvider).run()
+RunCollectionCoverageProviderScript(ContentCafeCoverageProvider).run()

--- a/content_cafe.py
+++ b/content_cafe.py
@@ -65,13 +65,11 @@ class ContentCafeCoverageProvider(MetadataWranglerBibliographicCoverageProvider)
                 mirror=mirror
             )
 
-        # We pass in registered_only=True because we don't need to cover
-        # every single ISBN in the system (most of which are alternate
-        # ISBNs found in OCLC Linked Data), only the ISBNs that a
-        # client specifically asked to look up.
+        # Any ISBN-type identifier cataloged in a Collection needs to
+        # be processed, whether or not it was explicitly registered.
         super(ContentCafeCoverageProvider, self).__init__(
-            collection=collection, registered_only=True,
-            replacement_policy=replacement_policy, **kwargs
+            collection=collection, replacement_policy=replacement_policy,
+            **kwargs
         )
         self.content_cafe = api or ContentCafeAPI.from_config(self._db)
 


### PR DESCRIPTION
This branch makes two minor but important changes to ContentCafeCoverageProvider to reflect the fact that it's now a CollectionCoverageProvider:

* The script that invokes it now treats it as a CollectionCoverageProvider.
* It processes even ISBNs that are not preregistered. Previously this wouldn't have worked because the metadata wrangler is full of random ISBNs obtained from OCLC Linked Data. But those ISBNs aren't cataloged in any collection. Now that ContentCafeCoverageProvider is a CollectionCoverageProvider, it only considers ISBNs that are cataloged in some collection, so the millions of OCLC ISBNs will be ignored anyway.