### PR TITLE
Add a simple dashboard

### DIFF
--- a/bin/informational/dashboard
+++ b/bin/informational/dashboard
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+"""Print a simple dashboard."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import DashboardScript
+DashboardScript().run()


### PR DESCRIPTION
This branch introduces a simple dashboard script which gives a basic overview of three things:

* The number of new LicensePools created over the past week. This roughly corresponds to new registrations, although for a while it's going to be picking up newly created LicensePools for ISBNs that were processed back when ISBNs didn't get Works.
* The number of Works updated over the past week. This roughly corresponds to coverage provided, though it might be either the initial coverage or some extra information we added later. I don't think we have a way to track when a Work object was created.
* For each collection, the percentage of Identifiers in that collection's catalog that have associated Works. This gives us a rough picture of where the problem spots are.

I'll provide the current output of this script privately.