### PR TITLE
Fix inverted queries in dashboard.

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -672,8 +672,8 @@ class DashboardScript(Script):
 
         types = set()
         for clause, counter in (
-                (LicensePool.work_id==None, done),
-                (LicensePool.work_id!=None, not_done),
+                (LicensePool.work_id!=None, done),
+                (LicensePool.work_id==None, not_done),
         ):
             qu = self._db.query(
                 Identifier.type,


### PR DESCRIPTION
This branch fixes a mix-up in the dashboard script where covered Identifiers were counted as uncovered, and vice versa. I noticed this when comparing two runs and noticing that the number of covered Identifiers appeared to be going down.