### PR TITLE
Rename book-covers.nypl.org URLs to covers.nypl.org

### DIFF
--- a/migration/20180626-move-cover-s3-bucket.sql
+++ b/migration/20180626-move-cover-s3-bucket.sql
@@ -1,0 +1,7 @@
+-- Replace all possible ways 'book-covers.nypl.org' might show up in
+-- a representation's mirror_url.
+update representations set mirror_url=replace(replace(replace(replace(replace(mirror_url, 'https://book-covers.nypl.org', 'https://covers.nypl.org'), 'https://s3.amazonaws.com/book-covers.nypl.org', 'https://covers.nypl.org'), 'http://covers.nypl.org', 'https://covers.nypl.org'), 'http://book-covers.nypl.org', 'https://covers.nypl.org'), 'http://s3.amazonaws.com/book-covers.nypl.org', 'https://covers.nypl.org') where mirror_url like '%covers.nypl.org%';
+
+-- Make sure that any work whose OPDS entry contains the old URL
+-- eventually has a new OPDS entry generated.
+delete from workcoveragerecords where operation='generate-opds' and work_id in (select id from works where verbose_opds_entry like '%book-covers.nypl.org%';


### PR DESCRIPTION
This branch changes the metadata wrangler's dataset to reflect the fact that all old cover images have been moved to the covers.nypl.org S3 bucket, and that there's no longer any need to refer to book-covers.nypl.org.

We could run the same migration script on every circulation manager, but that would mean a big one-time chunk of downtime. Since it's not urgent that we get rid of book-covers.nypl.org, for now I'm okay with changing the metadata wrangler and having the information gradually filter out to the circulation managers as metadata updates.

I'll attach the script I used to generate the complex "replace()" call in the SQL statement.

This should complete the work of https://jira.nypl.org/browse/SIMPLY-285.