### PR TITLE
Use the ErrorHandler from core

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from flask_babel import Babel
 from flask_sqlalchemy_session import flask_scoped_session
 
 from core.app_server import (
+    ErrorHandler,
     HeartbeatController,
     returns_problem_detail,
 )
@@ -58,6 +59,14 @@ def initialize_database(autoinitialize=True):
     app.log.info("Application debug mode: %r", app.debug)
     for logger in logging.getLogger().handlers:
         app.log.info("Logs are going to %r", logger)
+
+    # Register an error handler that logs exceptions through the
+    # normal logging process and tries to turn them into Problem
+    # Detail Documents.
+    h = ErrorHandler(app, app.config['DEBUG'])
+    @app.errorhandler(Exception)
+    def exception_handler(exception):
+        return h.handle(exception)
 
 def accepts_auth(f):
     @wraps(f)

--- a/controller.py
+++ b/controller.py
@@ -652,7 +652,10 @@ class CatalogController(object):
             )
         except Exception as e:
             log.error("Error retrieving URL", exc_info=e)
-            return REMOTE_INTEGRATION_ERROR
+            return REMOTE_INTEGRATION_ERROR.detailed(
+                _("Could not retrieve public key URL %(url)s",
+                  url=public_key_url)
+            )
 
         content_type = None
         if response.headers:
@@ -662,7 +665,9 @@ class CatalogController(object):
             # There's no JSON to speak of.
             log.error("Could not find OPDS 2 document: %s/%s",
                       response.content, content_type)
-            return INVALID_INTEGRATION_DOCUMENT
+            return INVALID_INTEGRATION_DOCUMENT.detailed(
+                _("Not an integration document: %(doc)s", doc=response.content)
+            )
 
         public_key_response = response.json()
 
@@ -685,7 +690,7 @@ class CatalogController(object):
                 client_url, base_public_key_url
             )
             return INVALID_INTEGRATION_DOCUMENT.detailed(
-                _("The public key integration document id doesn't match submitted url")
+                _("The public key integration document id (%(id)s) doesn't match submitted url %(url)s", id=client_url, url=base_public_key_url)
             )
 
         public_key = public_key_response.get('public_key')
@@ -712,7 +717,7 @@ class CatalogController(object):
                 )
             except Exception, e:
                 return INVALID_CREDENTIALS.detailed(
-                    _("Error decoding JWT: %s") % e.message
+                    _("Error decoding JWT: %(message)s", message=e.message)
                 )
 
             # The ability to create a valid JWT indicates control over


### PR DESCRIPTION
This branch makes the metadata wrangler use the same ErrorHandler class to handle exceptions that the circulation manager uses. Exceptions that affect database integrity will kill the process; other exceptions will be logged.

The motivating case is to make NYPL's metadata wrangler log the exceptions it encounters to Loggly so I don't have to SSH in and look at uwsgi.log.

This branch also gives some more specific error messages to the problem detail documents returned upon failures of the registration process.

Note that ErrorHandler has some code for rolling back a database session if there's an exception, which  won't work in the metadata wrangler because it doesn't define `app.manager`. We could certainly improve this, but it's not a big deal because the metadata wrangler has its own code for rolling back a database session if there's an exception.