### PR TITLE
Presentation edition scripts

### DIFF
--- a/bin/work_classification
+++ b/bin/work_classification
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""Re-classify any Works that need it.
+"""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.coverage import WorkClassificationCoverageProvider
+from core.scripts import RunWorkCoverageProviderScript
+RunWorkCoverageProviderScript(WorkClassificationCoverageProvider).run()

--- a/bin/work_presentation_coverage
+++ b/bin/work_presentation_coverage
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
-"""Calculate Work presentation for registered works."""
+"""Calculate Work presentation for registered works.
+
+Unlike work_presentation_editions, this will run even on Works
+that are not yet presentation-ready.
+"""
 import os
 import sys
 bin_dir = os.path.split(__file__)[0]

--- a/bin/work_presentation_editions
+++ b/bin/work_presentation_editions
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+"""Re-generate presentation editions of any Works that need it.
+
+This script is mainly triggered by
+migrations. work_presentation_editions is responsible for most of the
+presentation editions generated for works.
+"""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.coverage import WorkPresentationEditionCoverageProvider
+from core.scripts import RunWorkCoverageProviderScript
+RunWorkCoverageProviderScript(WorkPresentationEditionCoverageProvider).run()

--- a/integration_client.py
+++ b/integration_client.py
@@ -21,6 +21,11 @@ class WorkPresentationCoverageProvider(WorkCoverageProvider):
 
     """A CoverageProvider to reset the presentation for a Work as it
     achieves metadata coverage.
+
+    It would be good to have this subclass
+    core.coverage.WorkClassificationCoverageProvider,
+    but it needs to operate on all works, not just works that have
+    been made presentation-ready.
     """
 
     SERVICE_NAME = "Work Presentation Coverage Provider"

--- a/integration_client.py
+++ b/integration_client.py
@@ -57,6 +57,7 @@ class WorkPresentationCoverageProvider(WorkCoverageProvider):
             default_fiction=None, default_audience=None,
         )
         work.set_presentation_ready(exclude_search=True)
+        return work
 
 
 class CalculatesWorkPresentation(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Core requirements
 boto3
 elasticsearch==2.1.0
+elasticsearch-dsl<2.0.0
 pillow
 psycopg2
 requests==2.18.4
@@ -12,7 +13,6 @@ flask-sqlalchemy-session
 textblob
 isbnlib
 feedparser
-elasticsearch
 uwsgi
 pycrypto
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Core requirements
 boto3
+elasticsearch==2.1.0
 pillow
 psycopg2
 requests==2.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,8 @@ cairosvg==1.0.22
 Flask-Babel
 money
 pymarc
+accept-types
+watchtower # for cloudwatch logging
 
 # Ensure that we support SNI-based SSL
 ndg-httpsclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ psycopg2
 requests==2.18.4
 sqlalchemy==1.1.15
 nose
+urllib3<1.24 # Travis problem introduced 20181016 - check to see when we can remove
 lxml
 flask
 flask-sqlalchemy-session

--- a/tests/test_integration_client.py
+++ b/tests/test_integration_client.py
@@ -57,13 +57,16 @@ class TestWorkPresentationCoverageProvider(DatabaseTest):
         work = self._work()
         eq_(None, work.simple_opds_entry)
         eq_(None, work.verbose_opds_entry)
+        eq_(False, work.presentation_ready)
 
-        self.provider.process_item(work)
+        eq_(work, self.provider.process_item(work))
 
         # The OPDS entries have been calculated.
         assert work.simple_opds_entry != None
         assert work.verbose_opds_entry != None
 
+        # The work has been made presentation-ready.
+        eq_(True, work.presentation_ready)
 
 class TestCalculatesWorkPresentation(DatabaseTest):
 


### PR DESCRIPTION
This branch brings in the same scripts introduced to circulation by https://github.com/NYPL-Simplified/circulation/pull/1108.

The catch is that there's already very similar coverage provider in metadata, `WorkPresentationCoverageProvider`. I experimented with merging that coverage provider with core `WorkClassificationCoverageProvider`, but it didn't work, because `WorkPresentationCoverageProvider`  needs to operate on works that aren't already presentation-ready. So for now we've got three scripts in metadata that have confusingly similar names. I added lots of comments to try and reduce the confusion.

While I was doing these experiments I added a little test coverage to `WorkPresentationCoverageProvider` and fixed a problem that seems really bad (process_item wasn't returning the thing it processed) but apparently isn't -- I'm not sure why.