### PR TITLE
Move out old code

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -43,14 +43,6 @@ from content_cafe import (
     ContentCafeAPI,
 )
 
-from oclc.classify import (
-    OCLCClassifyCoverageProvider,
-)
-
-from oclc.linked_data import (
-    LinkedDataCoverageProvider,
-)
-
 from viaf import (
     VIAFClient,
 )
@@ -232,40 +224,19 @@ class IdentifierResolutionCoverageProvider(CatalogCoverageProvider):
         # These CoverageProviders can handle items from any kind of
         # collection, so long as the Identifier is of the right type.
 
-        # TODO: This is temporarily disabled -- it needs to become
-        # a CollectionCoverageProvider.
-        #
-        # There's no rush to get this working again because
-        # it was primarily intended for use with Project Gutenberg titles,
-        # which we've downplayed in favor of Feedbooks titles, which
-        # have much better metadata.
-        #
-        #oclc_classify = instantiate(
-        #    OCLCClassifyCoverageProvider, providers, provider_kwargs,
-        #    _db=self._db
-        #)
-
         content_cafe = instantiate(
             ContentCafeCoverageProvider, providers, provider_kwargs,
             collection=self.collection,
             replacement_policy=self.replacement_policy
         )
 
-        # TODO: This is temporarily disabled because its process_item doesn't
-        # work directly on ISBNs -- it assumes the ISBN has already been
-        # associated with OCLC Numbers in some other step. The best
-        # solution is to rearchitect LinkedDataCoverageProvider
-        # to make it assume it's processing ISBNs.
+        # NOTE: The coverage providers for OCLC Linked Data and
+        # the title/author version of OCLC Classify used to be in
+        # here.
         #
-        # This is fine for now because the main things we need out of the
-        # metadata wrangler are cover images and descriptions, which
-        # we can get from ContentCafeCoverageProvider.
-        #
-        #linked_data = instantiate(
-        #    LinkedDataCoverageProvider, providers, provider_kwargs,
-        #    collection=self.collection, replacement_policy=self.policy,
-        #    viaf=self.viaf
-        #)
+        # Those providers need to be rearchitected (and the
+        # title/author lookup one might just need to be removed), so
+        # they're gone for now.
 
         # All books identified by Overdrive ID must be looked up via
         # the Overdrive API. We don't enforce that the collection

--- a/oclc/classify.py
+++ b/oclc/classify.py
@@ -591,7 +591,7 @@ class OCLCClassifyAPI(object):
         return representation.content
 
 
-class OCLCClassifyTitleAuthorLookupCoverageProvider(IdentifierCoverageProvider):
+class TitleAuthorLookupCoverageProvider(IdentifierCoverageProvider):
     """Does title/author lookups using OCLC Classify.
 
     NOTE: This code is no longer used. It was designed to get extra
@@ -619,7 +619,7 @@ class OCLCClassifyTitleAuthorLookupCoverageProvider(IdentifierCoverageProvider):
     DATA_SOURCE_NAME = DataSource.OCLC
     
     def __init__(self, _db, api=None, **kwargs):
-        super(OCLCClassifyCoverageProvider, self).__init__(
+        super(TitleAuthorLookupCoverageProvider, self).__init__(
             _db, registered_only=True, **kwargs
         )
         self.api = api or OCLCClassifyAPI(self._db)

--- a/oclc/classify.py
+++ b/oclc/classify.py
@@ -591,11 +591,18 @@ class OCLCClassifyAPI(object):
         return representation.content
 
 
-class OCLCClassifyCoverageProvider(IdentifierCoverageProvider):
+class OCLCClassifyTitleAuthorLookupCoverageProvider(IdentifierCoverageProvider):
     """Does title/author lookups using OCLC Classify.
 
-    NOTE: This code is no longer used. It was designed for Project Gutenberg,
-    where 
+    NOTE: This code is no longer used. It was designed to get extra
+    metadata for titles from Project Gutenberg/Standard
+    Ebooks/unglue.it/Feedbooks, where the title and author are known
+    but there is no ISBN associated with the work.
+
+    Most of these data sources provide adequate metadata, except for
+    Project Gutenberg, which (generally speaking) we no longer use.
+    So for now we're focused on coverage providers that are more
+    reliable and give bigger bang for the (processing time) buck.
     """
 
     # Strips most non-alphanumerics from the title.

--- a/scripts.py
+++ b/scripts.py
@@ -45,7 +45,6 @@ from core.util.permanent_work_id import WorkIDCalculator
 from core.util.personal_names import contributor_name_match_ratio
 
 from oclc.linked_data import LinkedDataCoverageProvider
-from oclc.classify import OCLCClassifyCoverageProvider
 from viaf import VIAFClient
 
 

--- a/tests/_oclc/test_title_author_lookup_classify.py
+++ b/tests/_oclc/test_title_author_lookup_classify.py
@@ -17,7 +17,7 @@ from core.model import (
 
 from oclc.classify import (
     OCLCXMLParser,
-    OCLCClassifyCoverageProvider
+    TitleAuthorLookupCoverageProvider
 )
 from testing import MockOCLCClassifyAPI
 
@@ -338,16 +338,16 @@ class TestAuthorParser(DatabaseTest):
         self.assert_parse(s, s, Contributor.PRIMARY_AUTHOR_ROLE)
 
 
-class TestOCLCClassifyCoverageProvider(DatabaseTest):
+class TestTitleAuthorLookupCoverageProvider(DatabaseTest):
 
     def setup(self):
-        super(TestOCLCClassifyCoverageProvider, self).setup()
+        super(TestTitleAuthorLookupCoverageProvider, self).setup()
         self.edition, ignore = self._edition(
             with_license_pool=True, data_source_name=DataSource.GUTENBERG
         )
         self.identifier = self.edition.primary_identifier
         self.api = MockOCLCClassifyAPI()
-        self.provider = OCLCClassifyCoverageProvider(self._db, api=self.api)
+        self.provider = TitleAuthorLookupCoverageProvider(self._db, api=self.api)
 
     def sample_data(self, filename):
         return sample_data(filename, 'oclc_classify')
@@ -395,7 +395,7 @@ class TestOCLCClassifyCoverageProvider(DatabaseTest):
         eq_(result, self.identifier)
 
     def test_process_item_when_parsing_error_occurs(self):
-        class AlwaysErrorsClassifyProvider(OCLCClassifyCoverageProvider):
+        class AlwaysErrorsClassifyProvider(TitleAuthorLookupCoverageProvider):
             def parse_edition_data(self, *args, **kwargs):
                 raise IOError('It broke!')
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -18,7 +18,6 @@ from core.overdrive import MockOverdriveAPI
 from content_cafe import ContentCafeCoverageProvider
 from coverage import IdentifierResolutionCoverageProvider
 from integration_client import IntegrationClientCoverImageCoverageProvider
-from oclc.classify import OCLCClassifyCoverageProvider
 from overdrive import OverdriveBibliographicCoverageProvider
 from viaf import VIAFClient
 


### PR DESCRIPTION
Another simple cleanup branch in preparation for https://jira.nypl.org/browse/SIMPLY-1364.

Commented-out code was removed and OCLCClassifyCoverageProvider was renamed to TitleAuthorLookupCoverageProvider, since pretty soon there will be multiple CoverageProviders that use OCLC Classify.