### PR TITLE
Add oclc to providers

### DIFF
--- a/bin/oclc_classify_isbn_coverage
+++ b/bin/oclc_classify_isbn_coverage
@@ -7,6 +7,6 @@ package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
 
 from oclc.classify import IdentifierLookupCoverageProvider
-from core.scripts import RunCoverageProviderScript
+from core.scripts import RunCollectionCoverageProviderScript
 
-RunCoverageProviderScript(IdentifierLookupCoverageProvider).run()
+RunCollectionCoverageProviderScript(IdentifierLookupCoverageProvider).run()

--- a/coverage.py
+++ b/coverage.py
@@ -34,6 +34,8 @@ from core.mirror import MirrorUploader
 
 from core.util import fast_query_count
 
+from oclc.classify import IdentifierLookupCoverageProvider
+
 from overdrive import (
     OverdriveBibliographicCoverageProvider,
 )
@@ -251,6 +253,11 @@ class IdentifierResolutionCoverageProvider(CatalogCoverageProvider):
         # Those providers need to be rearchitected (and the
         # title/author lookup one might just need to be removed), so
         # they're gone for now.
+
+        oclc = instantiate(
+            IdentifierLookupCoverageProvider, providers, provider_kwargs,
+            collection=self.collection, replacement_policy=self.replacement_policy
+        )
 
         # All books identified by Overdrive ID must be looked up via
         # the Overdrive API. We don't enforce that the collection

--- a/migration/20181220-register-isbns-for-oclc-coverage.sql
+++ b/migration/20181220-register-isbns-for-oclc-coverage.sql
@@ -1,0 +1,16 @@
+-- Any existing OCLC Classify coverage for ISBNs doesn't count -- it
+-- needs to be redone. (But there shouldn't be any.)
+delete from coveragerecords where id in (
+ select cr.id from coveragerecords cr join datasources ds on cr.data_source_id=ds.id join identifiers i on cr.identifier_id=i.id where ds.name='OCLC Classify' and operation is null and i.type='ISBN'
+);
+
+-- For every ISBN associated with a collection, create a coverage
+-- record in the 'registered' state for the OCLC CLassify coverage
+-- provider.
+insert into coveragerecords (
+ identifier_id, data_source_id, timestamp, status
+) select 
+ i.id, ds.id, now(), 'registered'
+from collections_identifiers ci
+ join identifiers i on ci.identifier_id=i.id and i.type='ISBN'
+ join datasources ds on ds.name='OCLC Classify';

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -18,6 +18,7 @@ from core.overdrive import MockOverdriveAPI
 from content_cafe import ContentCafeCoverageProvider
 from coverage import IdentifierResolutionCoverageProvider
 from integration_client import IntegrationClientCoverImageCoverageProvider
+from oclc.classify import IdentifierLookupCoverageProvider
 from overdrive import OverdriveBibliographicCoverageProvider
 from viaf import VIAFClient
 
@@ -47,7 +48,6 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
             self._default_collection, provide_coverage_immediately=immediate,
             force=force, batch_size=93
         )
-
         # We aim to resolve all the identifiers in a given collection.
         eq_(self._default_collection, provider.collection)
 


### PR DESCRIPTION
This branch completes https://jira.nypl.org/browse/SIMPLY-1513 and https://jira.nypl.org/browse/SIMPLY-1514, which are the last remaining parts of https://jira.nypl.org/browse/SIMPLY-1364.

The OCLC Classify coverage provider is added to the list of coverage providers triggered when a new identifier comes into the system. The migration script makes it look like that has been happening all long by creating a big backlog of ISBN that need to be processed by the OCLC Classify provider.