### PR TITLE
Build a single Metadata object instead of building a number of them and applying them to the same Edition.

### DIFF
--- a/oclc/classify.py
+++ b/oclc/classify.py
@@ -157,7 +157,7 @@ class OCLCClassifyXMLParser(XMLParser):
         and update a list of existing MeasurementData.
         """
         tags = cls._xpath(tree, "//oclc:work")
-        for measurement in cls.get_measurements(tags, existing_measurements):
+        for measurement in cls.get_measurements(tags):
             key = measurement.quantity_measured
             if key in existing_measurements:
                 # We don't need another MeasurementData -- just add it to
@@ -177,7 +177,7 @@ class OCLCClassifyXMLParser(XMLParser):
     }
 
     @classmethod
-    def get_measurements(cls, work_tags, existing_measurements):
+    def get_measurements(cls, work_tags):
         """Extract MeasurementData representing values
         measured from a list of <work> tags.
 

--- a/oclc/classify.py
+++ b/oclc/classify.py
@@ -94,30 +94,36 @@ class OCLCClassifyXMLParser(XMLParser):
         return results
 
     @classmethod
-    def parse(cls, tree, identifiers):
-        """Process a preparsed XML document into Metadata.
+    def parse(cls, tree, metadata):
+        """Process a preparsed XML document and annotate a
+        preexisting Metadata with the result.
 
         :param tree: An XML document parsed with etree
-        :param identifiers: A list of Identifier and IdentifierData
-           objects representing the known identifiers associated
-           with a given book. The first object is the ISBN to be used
-           as the book's primary identifier.
-        :return A Metadata
+        :param metadata: A Metadata to be improved with the information
+            from the XML document.
         """
-        contributors = cls.contributors(tree)
-        measurements = cls.measurements(tree)
-        subjects = cls.subjects(tree)
-        primary_identifier = identifiers[0]
-        metadata = Metadata(
-            data_source=DataSource.OCLC,
-            contributors=contributors,
-            measurements=measurements,
-            subjects=subjects,
-            primary_identifier=primary_identifier,
-            identifiers=identifiers,
-        )
+        # If the Metadata already has ContributorData objects, do
+        # nothing -- otherwise we're likely to add duplicate or
+        # irrelevant information.
+        if not metadata.contributors:
+            metadata.contributors = cls.contributors(tree)
 
-        return metadata
+        # SubjectData and MeasurementData are additive. If two OWIs
+        # have the same classification the Metadata should get one
+        # SubjectData with the total weight.
+
+        # Build a dictionary mapping (type, identifier) to SubjectData,
+        # so that add_subjects() has an easier job.
+        existing_subjects = dict()
+        for subject in metadata.subjects:
+            existing_subjects[(subject.type, subject.identifier)] = subject
+        cls.add_subjects(tree, metadata, existing_subjects)
+
+        # Similarly for MeasurementData and add_measurements().
+        existing_measurements = dict()
+        for measurement in metadata.measurements:
+            existing_measurements[measurement.quantity_measured] = measurement
+        cls.add_measurements(tree, metadata, existing_measurements)
 
     # CONTRIBUTORS:
 
@@ -144,16 +150,32 @@ class OCLCClassifyXMLParser(XMLParser):
     # MEASUREMENTS:
 
     @classmethod
-    def measurements(cls, tree):
-        """Extract MeasurementData from a parsed XML document.
-
-        :return: A list of MeasurementData objects
+    def add_measurements(cls, tree, metadata, existing_measurements):
+        """Extract MeasurementData from a parsed XML document
+        and update a list of existing MeasurementData.
         """
         tags = cls._xpath(tree, "//oclc:work")
-        return cls.get_measurements(tags)
+        for measurement in cls.get_measurements(tags, existing_measurements):
+            key = measurement.quantity_measured
+            if key in existing_measurements:
+                # We don't need another MeasurementData -- just add it to
+                # the preexisting value.
+                existing_measurements[key].value += measurement.value
+            else:
+                # We do need another MeasurementData -- add it to the
+                # Metadata.
+                metadata.measurements.append(measurement)
+
+    # Maps OCLC attribute names to the link relations we use when
+    # creating Measurements.
+    MEASUREMENT_MAPPING = {
+        "holdings" : Measurement.HOLDINGS,
+        "eholdings" : Measurement.HOLDINGS,
+        "editions" : Measurement.PUBLISHED_EDITIONS,
+    }
 
     @classmethod
-    def get_measurements(cls, work_tags):
+    def get_measurements(cls, work_tags, existing_measurements):
         """Extract MeasurementData representing values
         measured from a list of <work> tags.
 
@@ -163,18 +185,16 @@ class OCLCClassifyXMLParser(XMLParser):
         :param work_tags: A list of preparsed <work> tags.
         :return: A list of MeasurementData objects
         """
-        data = {
-            "holdings": 0,
-            "editions": 0,
-        }
+        # Start with all possible values set to zero.
+        data = dict()
+        for rel in set(cls.MEASUREMENT_MAPPING.values()):
+            data[rel] = 0
 
         # In some cases, there are different versions of the book, each
         # listed under a different work tag with its own measurements; for each
         # type of measurement, we need to add up the numbers for each work tag.
         for work_tag in work_tags:
             cls._update_data(work_tag, data)
-            if work_tag.get("eholdings"):
-                data["holdings"] += int(work_tag.get("eholdings"))
 
         measurement_data_objects = cls.make_measurement_data(data)
         return measurement_data_objects
@@ -187,8 +207,8 @@ class OCLCClassifyXMLParser(XMLParser):
         :param work_tag: A preparsed <work> tag.
         :param data: A dictionary containing totals.
         """
-        for item in data:
-            data[item] += int(work_tag.get(item))
+        for key, rel in cls.MEASUREMENT_MAPPING.items():
+            data[rel] += int(work_tag.get(key))
 
     @classmethod
     def make_measurement_data(cls, data):
@@ -208,13 +228,23 @@ class OCLCClassifyXMLParser(XMLParser):
     # SUBJECTS
 
     @classmethod
-    def subjects(cls, tree):
-        """Extract SubjectData from a parsed XML document.
-
-        :return: A list of SubjectData objects
+    def add_subjects(cls, tree, metadata, existing_subjects):
+        """Extract SubjectData from a parsed XML document
+        and update a list of existing SubjectData.
         """
         classifiers = cls.get_classifier_names_and_parent_tags(tree)
         subjects = cls.get_subjects(classifiers)
+        for subject in subjects:
+            key = (subject.type, subject.identifier)
+            if key in existing_subjects:
+                # We don't need another SubjectData -- just bump up
+                # the weight on this old one.
+                existing_subjects[key].weight += subject.weight
+            else:
+                # We do need another SubjectData -- add it to the
+                # Metadata.
+                metadata.subjects.append(subject)
+
         return subjects
 
     @classmethod
@@ -1077,45 +1107,61 @@ class IdentifierLookupCoverageProvider(OCLCLookupCoverageProvider):
         return etree.fromstring(xml, parser=etree.XMLParser(recover=True))
 
     def process_item(self, identifier):
-        """Ask OCLC Classify about a single ISBN. Based on what
-        it says, create some number of Editions--either one for the
-        ISBN or one for every OWI associated with the ISBN.
+        """Ask OCLC Classify about a single ISBN. Create an Edition based on
+        what it says. This may involve consolidating information from
+        multiple OWIs.
+
+        TODO: Ideally we would create a distinct Metadata for each
+        OWI, and consolidate them into a presentation edition for the
+        ISBN. Unfortunately, a presentation edition only takes into account
+        information from different sources for the same Identifier.
+
+        Subject classification can be gathered across Identifiers, but
+        information such as author and measurements currently can not.
         """
         metadata_list = []
         failure = None
+
+        # Start with an empty Metadata. We're going to fill this out.
+        metadata = Metadata(
+            data_source=DataSource.OCLC,
+            primary_identifier=identifier
+        )
 
         try:
             tree = self._get_tree(isbn=identifier.identifier)
             code, owi_data = self.parser.initial_look_up(tree)
             if code in [self.parser.SINGLE_WORK_DETAIL_STATUS, self.parser.SINGLE_WORK_SUMMARY_STATUS]:
-                metadata_list = self._single(tree, identifier)
+                self._single(tree, metadata)
             elif code == self.parser.MULTI_WORK_STATUS:
-                metadata_list = self._multiple(owi_data, identifier)
+                self._multiple(owi_data, metadata)
             elif code == self.parser.NOT_FOUND_STATUS:
                 message = ("The work with %s %s was not found." % (identifier.type, identifier.identifier))
                 return self.failure(identifier, message)
-            if metadata_list:
-                for metadata in metadata_list:
-                    self._apply(metadata)
+            self._apply(metadata)
             return identifier
 
         except IOError as e:
             return self.failure(identifier, e.message)
 
-    def _single(self, tree, identifier):
-        """In the case of a single work response, go ahead and create a metadata object."""
-        return [self.parser.parse(tree, [identifier])]
+    def _single(self, tree, metadata):
+        """In the case of a single work response, annotate
+        `metadata` with the information it returned.
+        """
+        self.parser.parse(tree, metadata)
 
-    def _multiple(self, owi_data, identifier):
-        """In the case of a multi-work response, we don't have enough information to create
-        the metadata object right away; instead, for each <work> tag, we get a more complete document
-        by looking up the OWI, and create a Metadata object based on that."""
+    def _multiple(self, owi_data, metadata):
+        """In the case of a multi-work response, the document we got is
+        itself useless for annotating `metadata`.
+
+        Instead, for each <work> tag, we get a more complete document
+        by looking up the OWI, and annotate `metadata` based on
+        that.
+        """
         results = []
         for item in owi_data:
             tree_from_owi = self._get_tree(owi=item.identifier)
-            results.append(self.parser.parse(tree_from_owi, [identifier, item]))
-
-        return results
+            self.parser.parse(tree_from_owi, metadata)
 
     def _apply(self, metadata):
         """Create an edition based on a Metadata object we

--- a/tests/oclc_/test_classify_xml_parser.py
+++ b/tests/oclc_/test_classify_xml_parser.py
@@ -7,7 +7,8 @@ from .. import (
     sample_data
 )
 from lxml import etree
-from core.model import Contributor, Identifier
+from core.model import Contributor, DataSource, Identifier
+from core.metadata_layer import Metadata
 from oclc.classify import OCLCClassifyXMLParser
 
 class TestOCLCClassifyXMLParser(DatabaseTest):
@@ -46,7 +47,11 @@ class TestOCLCClassifyXMLParser(DatabaseTest):
     def test_parse(self):
         identifier = self._identifier()
         tree = self.tree("single_work_response.xml")
-        result = self.parser.parse(tree, [identifier])
+        metadata = Metadata(
+            data_source=DataSource.OCLC,
+            primary_identifier=identifier
+        )
+        result = self.parser.parse(tree, metadata)
         eq_([identifier], result.identifiers)
 
         # Contributors
@@ -72,9 +77,10 @@ class TestOCLCClassifyXMLParser(DatabaseTest):
         eq_([Contributor.AUTHOR_ROLE], melville.roles)
         eq_({'deathDate': '1891', 'birthDate': '1819'}, melville.extra)
 
+
         # Measurements
         def get_measurement(quantity):
-            [measurement] = [m.value for m in result.measurements if m.quantity_measured == quantity]
+            [measurement] = [m.value for m in result.measurements if m.quantity_measured == self.parser.MEASUREMENT_MAPPING[quantity]]
             return measurement
 
         eq_(46983, get_measurement("holdings"))


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-1583. Adriana has fixed the tests and I've verified that it works in a real environment.

In the multi-work case, we were making a Metadata object for each OWI, but instead of giving each Metadata object an OWI as its primary_identifier, we were giving it the original ISBN. When we called apply() on the first Metadata object, it associated all of its ContributorData, SubjectData, and MeasurementData with the original ISBN. That's fine, but when we called apply() on the second Metadata object:

* It associated all of its ContributorData with the original ISBN, adding to the first list of ContributorData. This had the effect of listing the same author multiple times.
* It overwrote the first set of Measurements for that ISBN with the second set. So if OWI #1 had 10 editions and OWI #2 had 13 editions, the final Measurement would be 13, not 23.
* It overwrote the first set of Classifications for that ISBN with the second set. So if OWI #1 had a weight of 102 for a certain subject, and OWI #2 had a weight of 10, the final Classification would have a weight of 10, not 112.

This branch changes the architecture so that we start with a single Metadata object, for the ISBN, and we improve it gradually as we iterate over the OWIs. This involves some code for detecting whether a MeasurementData already exists for a certain quantity (in which case we bump up the value measured) and whether a SubjectData already exists for a certain subject (in which case we bump up the weight).

This branch also addresses another problem I found while doing QA on the original OCLC Classify branch. Quantities are being stored under OCLC's names for them: 'holdings' and 'editions'. The names we should be using are constants defined in the Measurement class: HOLDINGS and PUBLISHED_EDITIONS.