### PR TITLE
Use the same ReplacementPolicy for all metadata coverage providers

### DIFF
--- a/content_cafe.py
+++ b/content_cafe.py
@@ -34,8 +34,6 @@ from core.model import (
 from core.util.http import HTTP
 from core.util.summary import SummaryEvaluator
 
-from core.mirror import MirrorUploader
-
 from coverage_utils import MetadataWranglerBibliographicCoverageProvider
 
 def load_file(filename):
@@ -58,7 +56,7 @@ class ContentCafeCoverageProvider(MetadataWranglerBibliographicCoverageProvider)
     INPUT_IDENTIFIER_TYPES = [Identifier.ISBN]
     DATA_SOURCE_NAME = DataSource.CONTENT_CAFE
 
-    def __init__(self, collection, api=None, replacement_policy=None, **kwargs):
+    def __init__(self, collection, api=None, **kwargs):
         """Constructor.
 
         :param collection: A Collection.
@@ -67,19 +65,12 @@ class ContentCafeCoverageProvider(MetadataWranglerBibliographicCoverageProvider)
         :param kwargs: Any extra arguments to be passed into the
             BibliographicCoverageProvider superconstructor.
         """
-        _db = Session.object_session(collection)
-        if not replacement_policy:
-            mirror = MirrorUploader.sitewide(_db)
-            replacement_policy = ReplacementPolicy.from_metadata_source(
-                mirror=mirror
-            )
-
         # Any ISBN-type identifier cataloged in a Collection needs to
         # be processed, whether or not it was explicitly registered.
         super(ContentCafeCoverageProvider, self).__init__(
-            collection=collection, replacement_policy=replacement_policy,
-            **kwargs
+            collection=collection, **kwargs
         )
+        _db = Session.object_session(collection)
         self.content_cafe = api or ContentCafeAPI.from_config(self._db)
 
     def process_item(self, identifier):

--- a/coverage_utils.py
+++ b/coverage_utils.py
@@ -42,8 +42,8 @@ class MetadataWranglerBibliographicCoverageProvider(BibliographicCoverageProvide
         # If the Identifier is already associated with a Work (because
         # we went through this process for another LicensePool for the
         # same identifier), we can reuse that Work and avoid a super()
-        # call, which will wastefully destroying the old Work and
-        # create a new one.
+        # call, which will wastefully destroy the old Work and create
+        # an identical new one.
         #
         # Normally this isn't necessary because
         # COVERAGE_COUNTS_FOR_EVERY_COLLECTION. But migration scripts
@@ -68,10 +68,7 @@ class MetadataWranglerBibliographicCoverageProvider(BibliographicCoverageProvide
         If a Work already existed, recalculate its presentation to
         incorporate the new metadata.
         """
-        work = super(
-            MetadataWranglerBibliographicCoverageProvider, self
-        ).work(identifier)
-
+        work = self.work(identifier)
         if not isinstance(work, Work):
             return work
 

--- a/coverage_utils.py
+++ b/coverage_utils.py
@@ -25,10 +25,9 @@ class MetadataWranglerBibliographicCoverageProvider(BibliographicCoverageProvide
         try:
             mirror = MirrorUploader.sitewide(_db)
         except CannotLoadConfiguration, e:
-            # It's not a fatal error if there's no MirrorUploader
+            # It's not a problem if there's no MirrorUploader
             # configured -- it just means we can't mirror cover images
             # when they show up.
-            self.log.error("No sitewide uploader configured", exc_info=e)
             mirror = None
         return ReplacementPolicy.from_metadata_source(mirror=mirror)
 

--- a/coverage_utils.py
+++ b/coverage_utils.py
@@ -3,9 +3,14 @@ from core.coverage import (
     BibliographicCoverageProvider,
     CoverageFailure
 )
-from core.model import DataSource
+from core.model import (
+    DataSource,
+    Work,
+)
 
 class MetadataWranglerBibliographicCoverageProvider(BibliographicCoverageProvider):
+
+    COVERAGE_COUNTS_FOR_EVERY_COLLECTION = True
 
     def work(self, identifier):
         # There should already be a dummy LicensePool, created by
@@ -23,11 +28,37 @@ class MetadataWranglerBibliographicCoverageProvider(BibliographicCoverageProvide
             if not license_pool.licenses_owned:
                 license_pool.update_availability(1, 1, 0, 0)
 
+        # Making the dummy LicensePool open-access will ensure that
+        # when multiple collections have the same book, they'll
+        # all share a Work.
+        license_pool.open_access = True
+
+        existing_work = identifier.work
+        if existing_work:
+            # We know which Work the LicensePool belongs to -- it's
+            # the one already associated with this identifier.
+            #
+            # This will avoid an expensive step where we create a new
+            # work unnecessarily.
+            license_pool.work = identifier.work
+
         return super(
             MetadataWranglerBibliographicCoverageProvider, self).work(
                 identifier, license_pool, even_if_no_title=True
             )
 
+
+    def handle_success(self, identifier):
+        work = super(MetadataWranglerBibliographicCoverageProvider, self).work(identifier)
+
+        if not isinstance(work, Work):
+            return work
+        if work.presentation_ready:
+            # This work was already presentation-ready, which means
+            # its presentation probably just changed and it needs to
+            # be recalculated.
+            work.calculate_presentation()
+        self.set_presentation_ready(identifier)
 
 class ResolveVIAFOnSuccessCoverageProvider(MetadataWranglerBibliographicCoverageProvider):
     """A mix-in class for metadata wrangler BibliographicCoverageProviders

--- a/migration/20181220-register-isbns-for-oclc-coverage.sql
+++ b/migration/20181220-register-isbns-for-oclc-coverage.sql
@@ -4,13 +4,15 @@ delete from coveragerecords where id in (
  select cr.id from coveragerecords cr join datasources ds on cr.data_source_id=ds.id join identifiers i on cr.identifier_id=i.id where ds.name='OCLC Classify' and operation is null and i.type='ISBN'
 );
 
--- For every ISBN associated with a collection, create a coverage
--- record in the 'registered' state for the OCLC CLassify coverage
--- provider.
+-- For every ISBN associated with a collection and not already
+-- registered, create a coverage record in the 'registered' state for
+-- the OCLC CLassify coverage provider.
 insert into coveragerecords (
  identifier_id, data_source_id, timestamp, status
 ) select 
- i.id, ds.id, now(), 'registered'
+ distinct(i.id), ds.id, now(), coverage_status('registered')
 from collections_identifiers ci
  join identifiers i on ci.identifier_id=i.id and i.type='ISBN'
- join datasources ds on ds.name='OCLC Classify';
+ join datasources ds on ds.name='OCLC Classify'
+ left join coveragerecords cr on i.id=cr.identifier_id and cr.data_source_id=5 and operation is null
+ where cr.id is null;

--- a/oclc/classify.py
+++ b/oclc/classify.py
@@ -15,6 +15,7 @@ from core.metadata_layer import (
     IdentifierData,
     MeasurementData,
     Metadata,
+    ReplacementPolicy,
     SubjectData,
 )
 from core.model import (
@@ -1169,7 +1170,10 @@ class IdentifierLookupCoverageProvider(OCLCLookupCoverageProvider):
         obtained by parsing a tree.
         """
         edition = self.edition(metadata.primary_identifier)
-        metadata.apply(edition, collection=None)
+        metadata.apply(
+            edition, collection=None, replace=self.replacement_policy
+        )
+
 
 class TitleAuthorLookupCoverageProvider(IdentifierCoverageProvider):
     """Does title/author lookups using OCLC Classify.
@@ -1203,6 +1207,13 @@ class TitleAuthorLookupCoverageProvider(IdentifierCoverageProvider):
             _db, registered_only=True, **kwargs
         )
         self.api = api or OCLCClassifyAPI(self._db)
+
+        # OCLC Classify never offers cover images, so there is no need
+        # for the ReplacementPolicy to be aware of whatever mirror
+        # is defined.
+        self.replacement_policy = ReplacementPolicy.from_metadata_source(
+            _db=self._db
+        )
 
     def oclc_safe_title(self, title):
         if not title:

--- a/oclc/classify.py
+++ b/oclc/classify.py
@@ -1208,13 +1208,6 @@ class TitleAuthorLookupCoverageProvider(IdentifierCoverageProvider):
         )
         self.api = api or OCLCClassifyAPI(self._db)
 
-        # OCLC Classify never offers cover images, so there is no need
-        # for the ReplacementPolicy to be aware of whatever mirror
-        # is defined.
-        self.replacement_policy = ReplacementPolicy.from_metadata_source(
-            _db=self._db
-        )
-
     def oclc_safe_title(self, title):
         if not title:
             return ''

--- a/overdrive.py
+++ b/overdrive.py
@@ -37,8 +37,7 @@ class OverdriveBibliographicCoverageProvider(
     # 'unaffiliated' collection, which is not an Overdrive collection.
     PROTOCOL = None
 
-    def __init__(self, collection, viaf=None, replacement_policy=None,
-                 **kwargs):
+    def __init__(self, collection, viaf=None, **kwargs):
         _db = Session.object_session(collection)
         api_class = kwargs.pop('api_class', OverdriveAPI)
         if callable(api_class):
@@ -53,15 +52,9 @@ class OverdriveBibliographicCoverageProvider(
 
         self.viaf = viaf or VIAFClient(_db)
 
-        if not replacement_policy:
-            replacement_policy = ReplacementPolicy.from_metadata_source(
-                mirror=MirrorUploader.sitewide(_db)
-            )
-
         kwargs['registered_only'] = True
         super(OverdriveBibliographicCoverageProvider, self).__init__(
-            collection, api_class=api, replacement_policy=replacement_policy,
-            **kwargs
+            collection, api_class=api, **kwargs
         )
 
     @classmethod

--- a/tests/oclc_/test_identifier_lookup_coverage_provider.py
+++ b/tests/oclc_/test_identifier_lookup_coverage_provider.py
@@ -124,6 +124,26 @@ class TestIdentifierLookupCoverageProvider(DatabaseTest):
         assert isinstance(failure, CoverageFailure)
         eq_(failure.exception, "The work with ISBN 9781429984171 was not found.")
 
+    def test__apply_propagates_replacement_policy(self):
+        # When IdentifierLookupCoverageProvider applies metadata
+        # to the database, it uses the replacement policy associated with
+        # the coverage provider.
+        class MockMetadata(Metadata):
+            def apply(self, *args, **kwargs):
+                self.called_with = (args, kwargs)
+
+        metadata = MockMetadata(data_source=DataSource.OCLC,
+                                primary_identifier=self._identifier())
+
+        provider = IdentifierLookupCoverageProvider(
+            self._default_collection, replacement_policy=object()
+        )
+        provider._apply(metadata)
+
+        args, kwargs = metadata.called_with
+        eq_(kwargs['replace'], provider.replacement_policy)
+
+
     def test__apply_single(self):
         # Testing that, in the case of a single-work response, _apply is called with the return value of _single.
         provider = MockProviderSingle(self._default_collection)

--- a/tests/test_content_cafe.py
+++ b/tests/test_content_cafe.py
@@ -345,33 +345,19 @@ class TestContentCafeCoverageProvider(DatabaseTest):
 
         # If no ContentCafeAPI is provided, the output of
         # ContentCafeAPI.from_config is used.
-        #
-        # If no MirrorUploader is provided, the output of
-        # S3Uploader.sitewide is used.
         class MockContentCafeAPI(ContentCafeAPI):
             @classmethod
             def from_config(cls, *args, **kwargs):
                 return mock_api
         content_cafe.ContentCafeAPI = MockContentCafeAPI
 
-        class MockUploader(MirrorUploader):
-            @classmethod
-            def sitewide(cls, *args, **kwargs):
-                return mock_mirror
-        # The content_cafe module has already imported MirrorUploader
-        # from core/mirror, so we need to mock it there rather than
-        # mocking mirror.
-        content_cafe.MirrorUploader = MockUploader
-
         # Now we can invoke the constructor with no special arguments
-        # and our mocked defaults will be used.
+        # and our mocked default will be used.
         provider = ContentCafeCoverageProvider(self._default_collection)
-        eq_(mock_mirror, provider.replacement_policy.mirror)
         eq_(mock_api, provider.content_cafe)
 
         # Restore mocked classes
         content_cafe.ContentCafeAPI = ContentCafeAPI
-        content_cafe.MirroUploader = MirrorUploader
 
     def test_process_item_success(self):
         class MockMetadata(object):
@@ -389,7 +375,7 @@ class TestContentCafeCoverageProvider(DatabaseTest):
         api = MockContentCafeAPI()
 
         provider = ContentCafeCoverageProvider(
-            self._default_collection, api, object()
+            self._default_collection, api
         )
         identifier = self._identifier()
 


### PR DESCRIPTION
This is a follow-up branch to fix https://jira.nypl.org/browse/SIMPLY-1583. It defines MetadataWranglerBibliographicCoverageProvider._default_replacement_policy to provide a reasonable default, so that individual coverage providers don't have to individually define a ReplacementPolicy. The problem remaining in 1583 was that the OCLC Classify coverage provider was using a ReplacementPolicy that added to lists of contributors instead of replacing contributors, so attempts to fix the problem only made it worse.

I spent quite a while tracking down a problem that was caused by an error in a migration script. Basically, if an ISBN was in multiple collections, we were registering multiple CoverageRecords for it, and duplicate work was being done in an extremely inefficient way. This branch includes a lot of defensive code so that if this happens again, the duplicate work will still happen, but it'll be much more efficient and reliable.

I've fixed the duplicate CoverageRecords on the metadata wrangler, and I've modified the migration script to say what it should have said in the first place. I've left the defensive code in place, even though it should no longer happen in a real environment.