### PR TITLE
Make the canonicalization controller able to handle invalid identifier URIs.

### DIFF
--- a/canonicalize.py
+++ b/canonicalize.py
@@ -263,6 +263,10 @@ class AuthorNameCanonicalizer(object):
 
 class MockAuthorNameCanonicalizer(AuthorNameCanonicalizer):
 
+    """Mocks the services used by the author name canonicalizer, but
+    leaves the logic alone.
+    """
+
     def __init__(self, _db, oclcld=None, viaf=None):
         super(MockAuthorNameCanonicalizer, self).__init__(_db)
         self._db = _db
@@ -324,3 +328,25 @@ class MockAuthorNameCanonicalizer(AuthorNameCanonicalizer):
             return self.non_response_results.pop()
         else:
             return None
+
+
+class SimpleMockAuthorNameCanonicalizer(AuthorNameCanonicalizer):
+    """Mocks the entire logic of AuthorNameCanonicalizer, allowing
+    the tester to simply define the 'correct' answers ahead of time.
+    """
+    def __init__(self):
+        self.mapping = {}
+        self.canonicalize_author_name_calls = []
+
+    def register(self, identifier, display_name, value):
+        """Register the canonical author name for an
+        (identifier, display_name) pair.
+        """
+        self.mapping[(identifier, display_name)] = value
+
+    def canonicalize_author_name(self, identifier, display_name):
+        """Record the fact that the method was called, and return
+        the predefined 'correct' answer.
+        """
+        self.canonicalize_author_name_calls.append((identifier, display_name))
+        return self.mapping.get((identifier, display_name), None)

--- a/oclc/classify.py
+++ b/oclc/classify.py
@@ -1083,8 +1083,27 @@ class OCLCClassifyAPI(object):
         """Perform an OCLC Classify lookup."""
         query_string = self.query_string(**kwargs)
         url = self.BASE_URL + query_string
+        return self._make_request(url)
+
+    def _make_request(self, url):
         representation, cached = Representation.get(self._db, url)
         return representation.content
+
+
+class MockOCLCClassifyAPI(OCLCClassifyAPI):
+
+    def __init__(self, _db):
+        super(MockOCLCClassifyAPI, self).__init__(_db)
+        self.requests = []
+        self.responses = []
+
+    def queue_response(self, content):
+        self.responses.append(content)
+
+    def _make_request(self, url):
+        self.requests.append(url)
+        return self.responses.pop(0)
+
 
 class OCLCLookupCoverageProvider(MetadataWranglerBibliographicCoverageProvider):
 

--- a/tests/files/oclc_classify/isbn_not_found.xml
+++ b/tests/files/oclc_classify/isbn_not_found.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<classify xmlns="http://classify.oclc.org">
+  <response code="102"/>
+</classify>

--- a/tests/files/oclc_classify/single_work_48446512.xml
+++ b/tests/files/oclc_classify/single_work_48446512.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<classify xmlns="http://classify.oclc.org">
+  <response code="2"/>
+  <!--Classify is a product of OCLC Online Computer Library Center: http://classify.oclc.org-->
+  <work author="Adams, Douglas, 1952-2001" editions="115" eholdings="359" format="Book" holdings="3432" itemtype="itemtype-book" owi="48446512" title="So long, and thanks for all the fish">11235977</work>
+  <authors>
+    <author lc="n80076765" viaf="113230702">Adams, Douglas, 1952-2001</author>
+  </authors>
+  <orderBy>thold desc</orderBy>
+  <input type="owi">48446512</input>
+  <start>0</start>
+  <maxRecs>25</maxRecs>
+  <editions>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="1514" itemtype="itemtype-book" language="eng" oclc="11235977" title="So long, and thanks for all the fish">
+      <classifications>
+        <class edition="19" ind1="0" ind2="0" sf2="19" sfa="823.914" tag="082"/>
+        <class ind1="0" ind2="0" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="367" itemtype="itemtype-book" language="eng" oclc="41169823" title="So long, and thanks for all the fish">
+      <classifications>
+        <class edition="21" ind1="0" ind2="4" sf2="21" sfa="823.914" tag="082"/>
+        <class ind1="0" ind2="0" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="267" itemtype="itemtype-book" language="eng" oclc="59818112" title="So long, and thanks for all the fish">
+      <classifications>
+        <class edition="22" ind1="0" ind2="0" sf2="22" sfa="823.914" tag="082"/>
+        <class ind1="0" ind2="0" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="259" format="eBook" holdings="0" itemtype="itemtype-book-digital" language="eng" oclc="464224528" title="So long, and thanks for all the fish">
+      <classifications>
+        <class ind1="1" ind2="4" sfa="PR6051.D3352" tag="050"/>
+        <class edition="22" ind1="0" ind2="4" sf2="22" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="159" itemtype="itemtype-book" language="eng" oclc="12122646" title="So long, and thanks for all the fish">
+      <classifications>
+        <class ind1="1" ind2="4" sfa="PR6051.D3352" tag="050"/>
+        <class edition="21" ind1="0" ind2="4" sf2="21" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="134" itemtype="itemtype-book" language="eng" oclc="69244356" title="So long, and thanks for all the fish">
+      <classifications>
+        <class edition="19" ind1="0" ind2=" " sf2="19" sfa="823.914" tag="082"/>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="133" itemtype="itemtype-book" language="eng" oclc="60425169" title="So long, and thanks for all the fish">
+      <classifications>
+        <class edition="0" ind1="0" ind2="4" sf2="00" sfa="823" tag="082"/>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="129" itemtype="itemtype-book" language="eng" oclc="27784832" title="So long, and thanks for all the fish">
+      <classifications>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+        <class edition="22" ind1="0" ind2="4" sf2="22" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="126" itemtype="itemtype-book" language="eng" oclc="12973955" title="So long, and thanks for all the fish : the hitchhikers' guide to the galaxy 4">
+      <classifications>
+        <class edition="19" ind1="0" ind2="4" sf2="19" sfa="823.914" tag="082"/>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+        <class edition="19" ind1="0" ind2="4" sf2="19" sfa="FIC" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="102" itemtype="itemtype-book" language="eng" oclc="373479708" title="So long, and thanks for all the fish">
+      <classifications>
+        <class ind1=" " ind2="4" sfa="PR6051" tag="050"/>
+        <class edition="22" ind1="0" ind2="4" sf2="22" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="69" itemtype="itemtype-book" language="eng" oclc="12487784" title="So long, and thanks for all the fish : the hitch hiker's guide to the galaxy 4">
+      <classifications>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+        <class edition="19" ind1="0" ind2="4" sf2="19" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="69" itemtype="itemtype-book" language="eng" oclc="48486855" title="So long, and thanks for all the fish">
+      <classifications>
+        <class edition="21" ind1="0" ind2="4" sf2="21" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="69" format="eBook" holdings="0" itemtype="itemtype-book-digital" language="eng" oclc="53140822" title="So long, and thanks for all the fish">
+      <classifications>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+        <class edition="22" ind1="0" ind2="4" sf2="22" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="53" itemtype="itemtype-book" language="eng" oclc="48363310" title="So long, and thanks for all the fish">
+      <classifications>
+        <class edition="21" ind1="0" ind2="4" sf2="21" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="50" itemtype="itemtype-book" language="eng" oclc="456550749" title="So long, and thanks for all the fish">
+      <classifications>
+        <class edition="22" ind1="0" ind2="4" sf2="22" sfa="823.914" tag="082"/>
+        <class ind1="1" ind2="4" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="28" itemtype="itemtype-book" language="eng" oclc="638190101" title="So long, and thanks for all the fish">
+      <classifications>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+        <class edition="20" ind1="0" ind2="4" sf2="20" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="23" itemtype="itemtype-book" language="eng" oclc="958125349" title="So long, and thanks for all the fish">
+      <classifications>
+        <class edition="23" ind1="0" ind2="4" sf2="23" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="14" format="eBook" holdings="0" itemtype="itemtype-book-digital" language="eng" oclc="920686057" title="So long, and thanks for all the fish">
+      <classifications>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+        <class edition="22" ind1="0" ind2="4" sf2="22" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="13" itemtype="itemtype-book" language="eng" oclc="156801618" title="So long, and thanks for all the fish">
+      <classifications>
+        <class ind1="1" ind2="4" sfa="PR6051.D3352" tag="050"/>
+        <class edition="22" ind1="0" ind2="4" sf2="22" sfa="813.6" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="9" itemtype="itemtype-book" language="ger" oclc="64259913" title="Macht's gut und danke für den Fisch"/>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="8" itemtype="itemtype-book" language="ger" oclc="76008698" title="Macht's gut, und danke für den Fisch"/>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="7" itemtype="itemtype-book" language="eng" oclc="379478111" title="So long, and thanks for all the fish">
+      <classifications>
+        <class edition="22" ind1="0" ind2="4" sf2="22" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="7" itemtype="itemtype-book" language="eng" oclc="971546960" title="So long, and thanks for all the fish">
+      <classifications>
+        <class edition="0" ind1="0" ind2="4" sf2="00" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="6" itemtype="itemtype-book" language="eng" oclc="670302570" title="So Long and Thanks For All the Fish">
+      <classifications>
+        <class edition="19" ind1="0" ind2="4" sf2="19" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="6" itemtype="itemtype-book" language="heb" oclc="59901796" title="So long, and thanks for all the fish">
+      <classifications>
+        <class edition="0" ind1="0" ind2="4" sf2="00" sfa="892.43" tag="082"/>
+      </classifications>
+    </edition>
+  </editions>
+  <recommendations>
+    <graph>http://chart.apis.google.com/chart?cht=p&amp;chd=e:-EB7&amp;chs=350x200&amp;chts=000000,16&amp;chtt=All+Editions&amp;chco=0D0399,124DBA&amp;chdl=Classified|Unclassified</graph>
+    <fast>
+      <graph>http://chart.apis.google.com/chart?cht=p&amp;chs=475x175&amp;chd=e:VBUkTbCSAs&amp;chco=0D0399,124DBA,278BD8,38C9E2,4DEADD&amp;chdl=Dent%2C+Arthur+%28Fictitious+character%29|Prefect%2C+Ford|Interplanetary+voyages|Interstellar+travel|Fiction</graph>
+      <headings>
+        <heading heldby="3504" ident="890366" src="fast">Dent, Arthur (Fictitious character)</heading>
+        <heading heldby="3413" ident="1075077" src="fast">Prefect, Ford</heading>
+        <heading heldby="3219" ident="977455" src="fast">Interplanetary voyages</heading>
+        <heading heldby="368" ident="977550" src="fast">Interstellar travel</heading>
+        <heading heldby="126" ident="923709" src="fast">Fiction</heading>
+      </headings>
+    </fast>
+    <ddc>
+      <mostPopular holdings="3500" nsfa="823.914" sfa="823.914"/>
+      <mostRecent holdings="3500" sfa="823.914"/>
+      <latestEdition holdings="32" sf2="23" sfa="823.914"/>
+      <graph>http://chart.apis.google.com/chart?cht=p&amp;chtt=DDC&amp;chs=350x200&amp;chts=000000,16&amp;chd=e:5uChB4AAAAAAB4&amp;chco=0D0399,124DBA,278BD8,38C9E2,4DEADD,6DF9A8,4DCC82&amp;chdl=823.914|823|FIC|813.6|892.43+%2F+B|830+%2F+820|Unclassified</graph>
+    </ddc>
+    <lcc>
+      <mostPopular holdings="3363" nsfa="PR6051.D3352" sfa="PR6051.D3352"/>
+      <mostRecent holdings="3363" sfa="PR6051.D3352"/>
+      <graph>http://chart.apis.google.com/chart?cht=p&amp;chtt=LCC&amp;chs=350x200&amp;chd=e:4YB6Ft&amp;chts=000000,16&amp;chco=0D0399,124DBA,278BD8&amp;chdl=PR6051.D3352|PR6051|Unclassified</graph>
+    </lcc>
+  </recommendations>
+  <navigation>
+    <pages>
+      <page>
+        <label>1</label>
+      </page>
+      <page>
+        <label>2</label>
+        <link>25</link>
+      </page>
+      <page>
+        <label>3</label>
+        <link>50</link>
+      </page>
+    </pages>
+    <next>25</next>
+    <last>100</last>
+  </navigation>
+</classify>

--- a/tests/files/oclc_classify/single_work_48525129.xml
+++ b/tests/files/oclc_classify/single_work_48525129.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<classify xmlns="http://classify.oclc.org">
+  <response code="2"/>
+  <!--Classify is a product of OCLC Online Computer Library Center: http://classify.oclc.org-->
+  <work author="Adams, Douglas, 1952-2001 | Gaiman, Neil" editions="45" eholdings="169" format="Book" holdings="2016" itemtype="itemtype-book" owi="48525129" title="The ultimate hitchhiker's guide to the galaxy">32924588</work>
+  <authors>
+    <author lc="n90640849" viaf="103859257">Gaiman, Neil</author>
+    <author lc="n80076765" viaf="113230702">Adams, Douglas, 1952-2001</author>
+  </authors>
+  <orderBy>thold desc</orderBy>
+  <input type="owi">48525129</input>
+  <start>0</start>
+  <maxRecs>25</maxRecs>
+  <editions>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="869" itemtype="itemtype-book" language="eng" oclc="49710059" title="The ultimate hitchhiker's guide to the galaxy">
+      <classifications>
+        <class edition="22" ind1="0" ind2="4" sf2="22" sfa="823.914" tag="082"/>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="752" itemtype="itemtype-book" language="eng" oclc="32924588" title="The ultimate hitchhiker's guide">
+      <classifications>
+        <class ind1="0" ind2="0" sfa="PR6051.D3352" tag="050"/>
+        <class edition="20" ind1="0" ind2="0" sf2="20" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="152" format="eBook" holdings="0" itemtype="itemtype-book-digital" language="eng" oclc="698461621" title="The ultimate hitchhiker's guide to the galaxy">
+      <classifications>
+        <class edition="22" ind1="0" ind2="4" sf2="22" sfa="823.914" tag="082"/>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="141" itemtype="itemtype-book" language="eng" oclc="57529697" title="The ultimate hitchhiker's guide : five complete novels and one story">
+      <classifications>
+        <class ind1="0" ind2="0" sfa="PR6051.D3352" tag="050"/>
+        <class edition="22" ind1="0" ind2="0" sf2="22" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="83" itemtype="itemtype-book" language="eng" oclc="37719730" title="The ultimate hitchhiker's guide">
+      <classifications>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+        <class edition="0" ind1="0" ind2="4" sf2="00" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="51" itemtype="itemtype-book" language="eng" oclc="830119017" title="The ultimate hitchhiker's guide to the galaxy">
+      <classifications>
+        <class ind1="1" ind2="4" sfa="PR6051.D3352" tag="050"/>
+        <class edition="21" ind1="0" ind2="4" sf2="21" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="24" itemtype="itemtype-book" language="eng" oclc="793307001" title="The ultimate hitchhiker's guide to the galaxy ; : The hitchhiker's guide to the galaxy ; The restaurant at the end of the universe ; Life, the universe, and everything ; So long, and thanks for all the fish ; Mostly harmless">
+      <classifications>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="15" itemtype="itemtype-book" language="eng" oclc="228438424" title="The ultimate hitchhiker's guide to the galaxy">
+      <classifications>
+        <class edition="20" ind1="0" ind2="0" sf2="20" sfa="823.914" tag="082"/>
+        <class ind1="0" ind2="0" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="12" itemtype="itemtype-book" language="eng" oclc="438964133" title="The ultimate hitchhiker's guide to the galaxy"/>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="8" itemtype="itemtype-book" language="eng" oclc="781903119" title="The ultimate hitchhiker's guide">
+      <classifications>
+        <class ind1="1" ind2="4" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="6" format="eBook" holdings="0" itemtype="itemtype-book-digital" language="eng" oclc="843017559" title="The ultimate hitchhiker's guide to the galaxy">
+      <classifications>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+        <class edition="22" ind1="0" ind2="4" sf2="22" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="5" itemtype="itemtype-book" language="eng" oclc="774132763" title="The ultimate hitchhiker's guide to the galaxy"/>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="5" itemtype="itemtype-book" language="eng" oclc="635808837" title="The ultimate hitchhiker's guide : five complete novels and one story">
+      <classifications>
+        <class ind1=" " ind2=" " sfa="PR6051.D3352" tag="050"/>
+        <class edition="0" ind1="0" ind2=" " sf2="00" sfa="823.914" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="5" format="eBook" holdings="0" itemtype="itemtype-book-digital" language="eng" oclc="1002082716" title="The Ultimate Hitchhiker's Guide to the Galaxy">
+      <classifications>
+        <class edition="0" ind1="1" ind2="4" sf2="00" sfa="E" tag="082"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="4" itemtype="itemtype-book" language="eng" oclc="978546998" title="Ultimate hitchhiker's guide">
+      <classifications>
+        <class edition="22" ind1="0" ind2="0" sf2="22" sfa="823.914" tag="082"/>
+        <class ind1="0" ind2="0" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="4" itemtype="itemtype-book" language="eng" oclc="786495978" title="Ultimate hitchhiker's guide : five complete novels and one story"/>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="4" itemtype="itemtype-book" language="eng" oclc="800257039" title="The ultimate hitchhiker's guide to the galaxy"/>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="3" itemtype="itemtype-book" language="eng" oclc="456586869" title="The ultimate hitchhiker's guide : complete &amp;amp; unabridged"/>
+    <edition eholdings="0" format="Book" holdings="3" itemtype="itemtype-book" language="eng" oclc="502043117" title="The Ultimate Hitchhiker's Guide to the Galaxy"/>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="3" itemtype="itemtype-book" language="eng" oclc="474519778" title="The ultimate hitchhiker's guide to the galaxy"/>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="3" format="eBook" holdings="0" itemtype="itemtype-book-digital" language="eng" oclc="851576446" title="The Ultimate Hitchhiker's Guide to the Galaxy : Entering the Tibetan Buddhist Path">
+      <classifications>
+        <class edition="22" ind1="0" ind2="4" sf2="22" sfa="823.914" tag="082"/>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="2" itemtype="itemtype-book" language="eng" oclc="493165947" title="The ultimate hitchhiker's guide"/>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="2" itemtype="itemtype-book" language="eng" oclc="762164452" title="The ultimate hitchhiker's guide : complete &amp;amp; unabridged"/>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="2" itemtype="itemtype-book" language="eng" oclc="832565957" title="The ultimate hitchhiker's guide">
+      <classifications>
+        <class edition="0" ind1="0" ind2="4" sf2="00" sfa="823.914" tag="082"/>
+        <class ind1=" " ind2="4" sfa="PR6051.D3352" tag="050"/>
+      </classifications>
+    </edition>
+    <edition author="Adams, Douglas, 1952-2001" eholdings="0" format="Book" holdings="2" itemtype="itemtype-book" language="eng" oclc="1010967270" title="The ultimate hitchhiker's guide to the galaxy"/>
+  </editions>
+  <recommendations>
+    <graph>http://chart.apis.google.com/chart?cht=p&amp;chd=e:-tBS&amp;chs=350x200&amp;chts=000000,16&amp;chtt=All+Editions&amp;chco=0D0399,124DBA&amp;chdl=Classified|Unclassified</graph>
+    <fast>
+      <graph>http://chart.apis.google.com/chart?cht=p&amp;chs=475x175&amp;chd=e:NzNzMhMhFsFs&amp;chco=0D0399,124DBA,278BD8,38C9E2,4DEADD,6DF9A8&amp;chdl=Humorous+stories%2C+English|Science+fiction%2C+English|Prefect%2C+Ford|Dent%2C+Arthur+%28Fictitious+character%29|Interplanetary+voyages|Interstellar+travel</graph>
+      <headings>
+        <heading heldby="2120" ident="963836" src="fast">Humorous stories, English</heading>
+        <heading heldby="2117" ident="1108670" src="fast">Science fiction, English</heading>
+        <heading heldby="1922" ident="1075077" src="fast">Prefect, Ford</heading>
+        <heading heldby="1922" ident="890366" src="fast">Dent, Arthur (Fictitious character)</heading>
+        <heading heldby="871" ident="977455" src="fast">Interplanetary voyages</heading>
+        <heading heldby="869" ident="977550" src="fast">Interstellar travel</heading>
+      </headings>
+    </fast>
+    <ddc>
+      <mostPopular holdings="2092" nsfa="823.914" sfa="823.914"/>
+      <mostRecent holdings="2092" sfa="823.914"/>
+      <latestEdition holdings="1177" sf2="22" sfa="823.914"/>
+      <latestEdition holdings="1" sf2="14" sfa="FIC"/>
+      <graph>http://chart.apis.google.com/chart?cht=p&amp;chtt=DDC&amp;chs=350x200&amp;chts=000000,16&amp;chd=e:9bAAAACk&amp;chdl=823.914|E|FIC|Unclassified&amp;chco=0D0399,124DBA,278BD8,38C9E2</graph>
+    </ddc>
+    <lcc>
+      <mostPopular holdings="2127" nsfa="PR6051.D3352" sfa="PR6051.D3352"/>
+      <mostRecent holdings="2127" sfa="PR6051.D3352"/>
+      <graph>http://chart.apis.google.com/chart?cht=p&amp;chtt=LCC&amp;chs=350x200&amp;chd=e:-EAAB7&amp;chts=000000,16&amp;chco=0D0399,124DBA,278BD8&amp;chdl=PR6051.D3352|PR6051|Unclassified</graph>
+    </lcc>
+  </recommendations>
+  <navigation>
+    <pages>
+      <page>
+        <label>1</label>
+      </page>
+      <page>
+        <label>2</label>
+        <link>25</link>
+      </page>
+    </pages>
+    <next>25</next>
+    <last>25</last>
+  </navigation>
+</classify>

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1341,10 +1341,14 @@ class TestCanonicalizationController(ControllerTest):
         m = self.controller.canonicalize_author_name
 
         # Test the success case.
+
+        # First, set up a predefined right answer for an
+        # Identifier/display name pair.
         identifier = self._identifier()
         input_name = "Bell Hooks"
         output_name = "hooks, bell"
         self.canonicalizer.register(identifier, input_name, output_name)
+
         with self.app.test_request_context(
                 '/?urn=%s&display_name=%s' % (identifier.urn, input_name)
         ):
@@ -1355,10 +1359,10 @@ class TestCanonicalizationController(ControllerTest):
             call = self.canonicalizer.canonicalize_author_name_calls.pop()
             eq_((identifier, input_name), call)
 
-            # And it returned the (predefined) right answer.
+            # And it returned the predefined right answer.
             eq_(200, response.status_code)
             eq_("text/plain", response.headers['Content-Type'])
-            eq_("hooks, bell", response.data)
+            eq_(output_name, response.data)
 
         # Now test the failure case.
         with self.app.test_request_context('/?urn=error&display_name=nobody'):


### PR DESCRIPTION
This branch fixes https://jira.nypl.org/browse/SIMPLY-1816, which causes the 500 error you can see by going [here](http://metadata.librarysimplified.org/canonical-author-name?display_name=Jeremy%20Robinson&urn=urn%3Aisbn%3ADBKACX0122823).

Passing an invalid URN into `Identifier.parse_urn` will raise a `ValueError`. Most of the time this is correct--a bad URN should put a stop to whatever we're trying to do--but in the context of the canonicalization controller, the URN is optional. If a bad URN is passed in, we should try to find the author's canonical name based solely on their display name.

Since the `CanonicalizationController` had no test coverage, I added tests for the whole thing.