### PR TITLE
Detect and handle the case where we're asked to canonicalize a 'display name' that's actually a sort name.

### DIFF
--- a/canonicalize.py
+++ b/canonicalize.py
@@ -129,6 +129,11 @@ class AuthorNameCanonicalizer(object):
 
 
     def _canonicalize(self, identifier, display_name):
+        if not ' ' in display_name:
+            # This is a one-named entity, like 'Cher' or 'Various'.
+            # The display name and sort name are identical.
+            return display_name
+
         # The best outcome would be that we already have a Contributor
         # with this exact display name and a known sort name.
         self.log.debug("Attempting to canonicalize %s", display_name)

--- a/tests/test_canonicalize.py
+++ b/tests/test_canonicalize.py
@@ -85,6 +85,26 @@ class TestAuthorNameCanonicalizer(DatabaseTest):
         eq_("Rand, Ayn", m('Rand, Ayn, and Cher'))
         eq_("Rand, Ayn", m('Rand, Ayn, and Kaling, Mindy'))
 
+    def test__canonicalize_single_name(self):
+        # For single-named entities, the sort name and display name
+        # are identical. We don't need to ask VIAF.
+        self.canonicalizer.viaf.queue_lookup("bad data")
+
+        for one_name in (
+            'Various',
+            'Anonymous',
+            'Cher',
+        ):
+            eq_(
+                one_name,
+                self.canonicalizer._canonicalize(
+                    identifier=None, display_name=one_name
+                )
+            )
+
+        # We didn't ask the mock VIAF about anything.
+        eq_(["bad data"], self.canonicalizer.viaf.results)
+
     def test_found_contributor(self):
         # If we find a matching contributor already in our database, 
         # then don't bother looking at OCLC or VIAF.

--- a/tests/test_canonicalize.py
+++ b/tests/test_canonicalize.py
@@ -53,11 +53,13 @@ class TestAuthorNameCanonicalizer(DatabaseTest):
         m = self.canonicalizer.primary_author_name
 
         # Test the simplest case.
-        eq_("Mindy Kaling", "Mindy Kaling")
+        eq_("Mindy Kaling", m("Mindy Kaling"))
 
         # Make sure only the first human's name is used.
         eq_("Mindy Kaling", m("Mindy Kaling, Bob Saget and Co"))
         eq_("Bill O'Reilly", m("Bill O'Reilly with Martin Dugard"))
+        eq_("Clare Verbeek",
+            m("Clare Verbeek, Thembani Dladla, Zanele Buthelezi"))
 
         # In most cases, when a sort name is passed in as a display
         # name, the situation is correctly diagnosed and the name is
@@ -66,6 +68,15 @@ class TestAuthorNameCanonicalizer(DatabaseTest):
             'Kaling, Mindy',
             'Tolkien, J. R. R.',
             'van Damme, Jean-Claude',
+        ):
+            eq_(sort_name, m(sort_name))
+
+        # Similarly when there is no distinction between display
+        # and sort name.
+        for sort_name in (
+            'Cher',
+            'Various',
+            'Anonymous',
         ):
             eq_(sort_name, m(sort_name))
 

--- a/tests/test_canonicalize.py
+++ b/tests/test_canonicalize.py
@@ -50,11 +50,6 @@ class TestAuthorNameCanonicalizer(DatabaseTest):
     def test_primary_author_name(self):
         # Test our ability to turn a freeform string that identifies
         # one or more people into the likely name of one person.
-        #
-        # TODO: Cases we can't handle:
-        #  van Damme, Jean Claude
-        #  Madonna, Cher
-        #  Ryan and Josh Shook
         m = self.canonicalizer.primary_author_name
 
         # Test the simplest case.

--- a/tests/test_canonicalize.py
+++ b/tests/test_canonicalize.py
@@ -48,11 +48,36 @@ class TestAuthorNameCanonicalizer(DatabaseTest):
 
 
     def test_primary_author_name(self):
-        # Make sure only the first human's name is used.
-        name = "Mindy Kaling, Bob Saget and Co"
-        extracted_name = self.canonicalizer.primary_author_name(name)
-        eq_("Mindy Kaling", extracted_name)
+        # Test our ability to turn a freeform string that identifies
+        # one or more people into the likely name of one person.
+        #
+        # TODO: Cases we can't handle:
+        #  van Damme, Jean Claude
+        #  Madonna, Cher
+        #  Ryan and Josh Shook
+        m = self.canonicalizer.primary_author_name
 
+        # Test the simplest case.
+        eq_("Mindy Kaling", "Mindy Kaling")
+
+        # Make sure only the first human's name is used.
+        eq_("Mindy Kaling", m("Mindy Kaling, Bob Saget and Co"))
+        eq_("Bill O'Reilly", m("Bill O'Reilly with Martin Dugard"))
+
+        # In most cases, when a sort name is passed in as a display
+        # name, the situation is correctly diagnosed and the name is
+        # returned as-is.
+        for sort_name in (
+            'Kaling, Mindy',
+            'Tolkien, J. R. R.',
+            'van Damme, Jean-Claude',
+        ):
+            eq_(sort_name, m(sort_name))
+
+        # These are not likely to show up in real usage, but we can
+        # handle them.
+        eq_("Rand, Ayn", m('Rand, Ayn, and Cher'))
+        eq_("Rand, Ayn", m('Rand, Ayn, and Kaling, Mindy'))
 
     def test_found_contributor(self):
         # If we find a matching contributor already in our database, 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -970,6 +970,7 @@ class TestURNLookupController(ControllerTest):
 
         self.overdrive_collection = MockOverdriveAPI.mock_collection(self._db)
         self.overdrive = MockOverdriveAPI(self._db, self.overdrive_collection)
+        self.overdrive.queue_collection_token()
 
         self.viaf = MockVIAFClient(self._db)
 

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -31,9 +31,11 @@ class TestOverdriveBibliographicCoverageProvider(DatabaseTest):
         replacement_policy = ReplacementPolicy.from_metadata_source(
             mirror=mirror
         )
+        api = MockOverdriveAPI(self._db, collection)
+        api.queue_collection_token()
         provider = OverdriveBibliographicCoverageProvider(
             collection, replacement_policy=replacement_policy,
-            api_class=MockOverdriveAPI
+            api_class=api
         )
         
         # Any resources discovered by Overdrive will be


### PR DESCRIPTION
With very little work, this will prevent almost all of the metadata wrangler timeouts described in https://jira.nypl.org/browse/SIMPLY-1818.