### PR TITLE
Make the Python 2 code forward-compatible with Python 3

### DIFF
--- a/content_cafe.py
+++ b/content_cafe.py
@@ -38,7 +38,7 @@ def load_file(filename):
     this_dir = os.path.split(__file__)[0]
     content_dir = os.path.join(this_dir, "files", "content-cafe")
     path = os.path.join(content_dir, filename)
-    return open(path).read()
+    return open(path, 'rb').read()
 
 
 class ContentCafeCoverageProvider(MetadataWranglerBibliographicCoverageProvider):
@@ -270,28 +270,28 @@ class ContentCafeAPI(object):
     def add_reviews(self, metadata, identifier, args):
         return self.annotate_with_web_resources(
             metadata, identifier, args, self.review_url,
-            'No review info exists for this item',
+            b'No review info exists for this item',
             Hyperlink.REVIEW, self._scrape_list
         )
 
     def add_descriptions(self, metadata, identifier, args):
         return self.annotate_with_web_resources(
             metadata, identifier, args, self.summary_url,
-            'No annotation info exists for this item',
+            b'No annotation info exists for this item',
             Hyperlink.DESCRIPTION, self._scrape_list
         )
 
     def add_author_notes(self, metadata, identifier, args):
         return self.annotate_with_web_resources(
             metadata, identifier, args, self.author_notes_url,
-            'No author notes info exists for this item',
+            b'No author notes info exists for this item',
             Hyperlink.AUTHOR, self._scrape_one
         )
 
     def add_excerpt(self, metadata, identifier, args):
         return self.annotate_with_web_resources(
             metadata, identifier, args, self.excerpt_url,
-            'No excerpt info exists for this item', Hyperlink.SAMPLE,
+            b'No excerpt info exists for this item', Hyperlink.SAMPLE,
             self._scrape_one
         )
 

--- a/oclc/classify.py
+++ b/oclc/classify.py
@@ -1072,7 +1072,7 @@ class OCLCClassifyAPI(object):
         return DataSource.lookup(self._db, DataSource.OCLC)
 
     def query_string(self, **kwargs):
-        # TODO PYTHON3 this will be urllib.parse
+        # TODO PYTHON3 this will be urllib.parse.urlencode
         return urllib.urlencode(sorted(kwargs.items()))
 
     def lookup_by(self, **kwargs):

--- a/oclc/classify.py
+++ b/oclc/classify.py
@@ -1005,7 +1005,7 @@ class OCLCTitleAuthorLookupXMLParser(XMLParser):
         oclc_number = unicode(edition_tag.get('oclc'))
         try:
             int(oclc_number)
-        except ValueError, e:
+        except ValueError as e:
             # This record does not have a valid OCLC number.
             return None, False
 
@@ -1072,12 +1072,8 @@ class OCLCClassifyAPI(object):
         return DataSource.lookup(self._db, DataSource.OCLC)
 
     def query_string(self, **kwargs):
-        args = dict()
-        for k, v in kwargs.items():
-            if isinstance(v, unicode):
-                v = v.encode("utf8")
-            args[k] = v
-        return urllib.urlencode(sorted(args.items()))
+        # TODO PYTHON3 this will be urllib.parse
+        return urllib.urlencode(sorted(kwargs.items()))
 
     def lookup_by(self, **kwargs):
         """Perform an OCLC Classify lookup."""
@@ -1163,7 +1159,7 @@ class IdentifierLookupCoverageProvider(OCLCLookupCoverageProvider):
             return identifier
 
         except IOError as e:
-            return self.failure(identifier, e.message)
+            return self.failure(identifier, unicode(e))
 
     def _single(self, tree, metadata):
         """In the case of a single work response, annotate
@@ -1258,11 +1254,7 @@ class TitleAuthorLookupCoverageProvider(IdentifierCoverageProvider):
 
         # Log the info
         def _f(s):
-            if not s:
-                return ''
-            if isinstance(s, unicode):
-                return s.encode("utf8")
-            return s
+            return s or ''
         self.log.info(
             '%s "%s" "%s" %r', _f(edition.primary_identifier.identifier),
             _f(title), _f(author), _f(language)
@@ -1370,7 +1362,7 @@ class TitleAuthorLookupCoverageProvider(IdentifierCoverageProvider):
         try:
             records = self.parse_edition_data(xml, edition, title, language)
         except IOError as e:
-            return self.failure(identifier, e.message)
+            return self.failure(identifier, unicode(e))
 
         self.merge_contributors(edition, records)
         self.log.info("Created %s records(s).", len(records))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,5 +14,5 @@ def sample_data(filename, sample_data_dir):
     resource_path = os.path.join(base_path, "files", sample_data_dir)
     path = os.path.join(resource_path, filename)
 
-    with open(path) as f:
+    with open(path, 'rb') as f:
         return f.read()

--- a/tests/oclc_/test_linked_data.py
+++ b/tests/oclc_/test_linked_data.py
@@ -297,7 +297,6 @@ class TestLinkedDataCoverageProvider(DatabaseTest):
 
         provider.process_item(identifier)
 
-
         # Both VIAF-identified authors have had their information updated
         # with the VIAF results.
         filled_in = sorted(

--- a/tests/oclc_/test_title_author_lookup_classify.py
+++ b/tests/oclc_/test_title_author_lookup_classify.py
@@ -164,13 +164,13 @@ class TestParser(DatabaseTest):
         # Most of the contributors have LC and VIAF numbers, but two
         # (Cliffs Notes and Rockwell Kent) do not.
         eq_(
-            [None, None, u'n50025038', u'n50050335', u'n79006936',
+            ['', '', u'n50025038', u'n50050335', u'n79006936',
              u'n79059764'],
-            sorted([x.lc for x in work.contributors])
+            sorted([x.lc or '' for x in work.contributors])
         )
         eq_(
-            [None, None, u'27068555', u'34482742', u'4947338', u'51716047'],
-            sorted([x.viaf for x in work.contributors]))
+            ['', '', u'27068555', u'34482742', u'4947338', u'51716047'],
+            sorted([x.viaf or '' for x in work.contributors]))
 
         # Only two of the contributors are considered 'authors' by
         # OCLC. Herman Melville is the primary author, and Tony Tanner is

--- a/tests/test_canonicalize.py
+++ b/tests/test_canonicalize.py
@@ -10,7 +10,7 @@ from . import (
 
 from core.metadata_layer import ContributorData
 
-from test_viaf import MockVIAFClientLookup
+from .test_viaf import MockVIAFClientLookup
 
 from canonicalize import (
     AuthorNameCanonicalizer, 

--- a/tests/test_content_cafe.py
+++ b/tests/test_content_cafe.py
@@ -284,7 +284,7 @@ class TestContentCafeAPI(ContentCafeAPITest, DatabaseTest):
         reviews = metadata.links
         eq_(6, len(reviews))
         assert all([x.rel==Hyperlink.REVIEW for x in reviews])
-        assert "isn't a myth!" in reviews[0].content
+        assert "isn't a myth!" in reviews[0].content.decode("utf8")
 
         # We incidentally figured out the book's title.
         eq_("Shadow Thieves", metadata.title)
@@ -298,7 +298,7 @@ class TestContentCafeAPI(ContentCafeAPITest, DatabaseTest):
 
         [notes] = metadata.links
         eq_(Hyperlink.AUTHOR, notes.rel)
-        assert 'Brenda researched turtles' in notes.content
+        assert 'Brenda researched turtles' in notes.content.decode("utf8")
 
         # We incidentally figured out the book's title.
         eq_("Franklin's Christmas Gift", metadata.title)
@@ -312,7 +312,7 @@ class TestContentCafeAPI(ContentCafeAPITest, DatabaseTest):
 
         [excerpt] = metadata.links
         eq_(Hyperlink.SAMPLE, excerpt.rel)
-        assert 'Franklin loved his marbles.' in excerpt.content
+        assert 'Franklin loved his marbles.' in excerpt.content.decode("utf8")
 
         # We incidentally figured out the book's title.
         eq_("Franklin's Christmas Gift", metadata.title)
@@ -352,7 +352,7 @@ class TestContentCafeAPI(ContentCafeAPITest, DatabaseTest):
 
         # Otherwise, it's fine. We don't check that the image is
         # valid, only that it's not a stand-in image.
-        eq_(True, m("I'm not a stand-in image."))
+        eq_(True, m(b"I'm not a stand-in image."))
 
 
 class TestContentCafeCoverageProvider(DatabaseTest):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -162,7 +162,7 @@ class TestCollectionHandling(ControllerTest):
 
         # The DataSource can also be set via arguments.
         eq_(None, collection.data_source)
-        # TODO PYTHON3 this will be urllib.parse
+        # TODO PYTHON3 this will be urllib.parse.quote
         source = 'data_source=%s' % urllib.quote(DataSource.OA_CONTENT_SERVER)
         with self.app.test_request_context('/?%s' % source):
             result = collection_from_details(self._db, self.client, details)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
+import base64 as stdlib_base64
 import os
-import base64
 import feedparser
 import json
 import re
@@ -9,7 +9,7 @@ from Crypto.Cipher import PKCS1_OAEP
 from Crypto.Hash import SHA
 from Crypto.Signature import PKCS1_v1_5
 from Crypto.PublicKey import RSA
-from StringIO import StringIO
+from io import BytesIO
 from datetime import datetime, timedelta
 from functools import wraps
 import jwt
@@ -45,6 +45,7 @@ from core.testing import (
 )
 from core.util.problem_detail import ProblemDetail
 from core.util.opds_writer import OPDSMessage
+from core.util.string_helpers import base64
 
 from canonicalize import (
     AuthorNameCanonicalizer,
@@ -161,6 +162,7 @@ class TestCollectionHandling(ControllerTest):
 
         # The DataSource can also be set via arguments.
         eq_(None, collection.data_source)
+        # TODO PYTHON3 this will be urllib.parse
         source = 'data_source=%s' % urllib.quote(DataSource.OA_CONTENT_SERVER)
         with self.app.test_request_context('/?%s' % source):
             result = collection_from_details(self._db, self.client, details)
@@ -240,13 +242,13 @@ class TestCatalogController(ControllerTest):
     @classmethod
     def get_root(cls, raw_feed):
         """Returns the root tag of an OPDS or XML feed."""
-        return etree.parse(StringIO(raw_feed))
+        return etree.parse(BytesIO(raw_feed))
 
     @classmethod
     def get_messages(cls, root):
         """Returns the OPDSMessages from a feed, given its root tag."""
         message_path = '/atom:feed/simplified:message'
-        if isinstance(root, basestring):
+        if isinstance(root, (bytes, str)):
             root = cls.get_root(root)
         return cls.XML_PARSE(root, message_path)
 
@@ -256,7 +258,7 @@ class TestCatalogController(ControllerTest):
 
     @classmethod
     def get_message_for(cls, identifier, messages):
-        if not isinstance(identifier, basestring):
+        if not isinstance(identifier, (bytes, str)):
             identifier = identifier.urn
         [message] = [m for m in messages
                      if cls.xml_value(m, 'atom:id')==identifier]
@@ -438,7 +440,7 @@ class TestCatalogController(ControllerTest):
             links = feedparser.parse(response.get_data())['feed']['links']
             assert any([link['rel'] == 'next' for link in links])
             assert not any([link['rel'] == 'previous' for link in links])
-            assert not any([link['rel'] == 'first' for l in links])
+            assert not any([link['rel'] == 'first' for link in links])
 
         with self.app.test_request_context('/?size=1&after=1',
             headers=self.valid_auth
@@ -555,7 +557,7 @@ class TestCatalogController(ControllerTest):
         eq_(HTTP_OK, response.status_code)
 
         # It sends one message.
-        root = etree.parse(StringIO(response.data))
+        root = etree.parse(BytesIO(response.data))
         [catalogued] = self.get_messages(response.get_data())
 
         # The identifier in the OPDS feed is still in the catalog.
@@ -817,7 +819,7 @@ class TestCatalogController(ControllerTest):
 
         # Put the new key in the mock catalog.
         mock_auth_json = json.loads(self.sample_data('public_key_document.json'))
-        mock_auth_json['public_key']['value'] = key.exportKey()
+        mock_auth_json['public_key']['value'] = key.exportKey().decode("utf8")
         mock_public_key_doc = json.dumps(mock_auth_json)
         mock_doc_response = MockRequestsResponse(
             200, content=mock_public_key_doc,
@@ -841,8 +843,10 @@ class TestCatalogController(ControllerTest):
         catalog = json.loads(response.data)
         eq_(url, catalog.get('id'))
         shared_secret = catalog.get('metadata').get('shared_secret')
-        shared_secret = encryptor.decrypt(base64.b64decode(shared_secret))
-        eq_(client.shared_secret, shared_secret)
+        decrypted_secret = encryptor.decrypt(
+            stdlib_base64.b64decode(shared_secret)
+        ).decode("utf8")
+        eq_(client.shared_secret, decrypted_secret)
 
         # If the client already has a shared_secret, a request cannot
         # succeed without providing it.
@@ -870,8 +874,10 @@ class TestCatalogController(ControllerTest):
         # It has a new shared_secret.
         assert client.shared_secret != 'token'
         shared_secret = catalog.get('metadata').get('shared_secret')
-        shared_secret = encryptor.decrypt(base64.b64decode(shared_secret))
-        eq_(client.shared_secret, shared_secret)
+        decrypted_secret = encryptor.decrypt(
+            stdlib_base64.b64decode(shared_secret)
+        ).decode("utf8")
+        eq_(client.shared_secret, decrypted_secret)
 
     def test_register_with_jwt(self):
         # Create an encryptor so we can compare secrets later. :3
@@ -892,7 +898,7 @@ class TestCatalogController(ControllerTest):
 
         # Put the public key in the mock catalog.
         mock_auth_json = json.loads(self.sample_data('public_key_document.json'))
-        mock_auth_json['public_key']['value'] = key.publickey().exportKey()
+        mock_auth_json['public_key']['value'] = key.publickey().exportKey().decode("utf8")
         mock_public_key_doc = json.dumps(mock_auth_json)
         mock_doc_response = MockRequestsResponse(
             200, content=mock_public_key_doc,
@@ -919,8 +925,10 @@ class TestCatalogController(ControllerTest):
         catalog = json.loads(response.data)
         eq_(url, catalog.get('id'))
         shared_secret = catalog.get('metadata').get('shared_secret')
-        shared_secret = encryptor.decrypt(base64.b64decode(shared_secret))
-        eq_(client.shared_secret, shared_secret)
+        decrypted_secret = encryptor.decrypt(
+            stdlib_base64.b64decode(shared_secret)
+        ).decode("utf8")
+        eq_(client.shared_secret, decrypted_secret)
 
         # Since a JWT always proves ownership of test.org, we allow
         # clients who provide a JWT to modify an existing shared
@@ -960,7 +968,7 @@ class TestURNLookupController(ControllerTest):
 
     def data_file(self, path):
         """Return the contents of a test data file."""
-        return open(os.path.join(self.resource_path, path)).read()
+        return open(os.path.join(self.resource_path, path), 'rb').read()
 
     def setup(self):
         super(TestURNLookupController, self).setup()
@@ -1082,7 +1090,7 @@ class TestURNLookupController(ControllerTest):
         # The CoverageRecords exist on the Identifier -- it's not
         # something that was made up for the OPDS message.
         [overdrive_cr, resolver_cr] = sorted(
-            identifier.coverage_records, key=lambda x: x.operation
+            identifier.coverage_records, key=lambda x: x.operation or ""
         )
         eq_(DataSource.INTERNAL_PROCESSING, resolver_cr.data_source.name)
         eq_(CoverageRecord.RESOLVE_IDENTIFIER_OPERATION, resolver_cr.operation)
@@ -1363,7 +1371,7 @@ class TestCanonicalizationController(ControllerTest):
             # And it returned the predefined right answer.
             eq_(200, response.status_code)
             eq_("text/plain", response.headers['Content-Type'])
-            eq_(output_name, response.data)
+            eq_(output_name, response.data.decode("utf8"))
 
         # Now test the failure case.
         with self.app.test_request_context('/?urn=error&display_name=nobody'):
@@ -1377,4 +1385,4 @@ class TestCanonicalizationController(ControllerTest):
             # Since there was no predefined right answer for (None, "nobody"),
             # we get a 404 error.
             eq_(404, response.status_code)
-            eq_("", response.data)
+            eq_("", response.data.decode("utf8"))

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -23,7 +23,7 @@ class TestOverdriveBibliographicCoverageProvider(DatabaseTest):
 
     def data_file(self, path):
         """Return the contents of a test data file."""
-        return open(os.path.join(self.resource_path, path)).read()
+        return open(os.path.join(self.resource_path, path), 'rb').read()
 
     def test_replacement_policy_uses_provided_mirror(self):
         collection = MockOverdriveAPI.mock_collection(self._db)


### PR DESCRIPTION
All this stuff should be familiar from our work on core and circulation.

I'm less confident in the Python 3 conversion for this product because our test coverage isn't as good here as for circulation, core, and library_registry.