### PR TITLE
A disabled IntegrationClient can't use an authentication-required service

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -135,6 +135,10 @@ class MetadataWrangler(object):
 
             if client:
                 # Success!
+                if not client.enabled:
+                    # But the client has been disabled.
+                    return DISABLED_CLIENT
+
                 flask.request.authenticated_client = client
                 return client
             else:

--- a/integration_client.py
+++ b/integration_client.py
@@ -12,9 +12,9 @@ from core.coverage import (
 )
 from core.metadata_layer import (
     Metadata,
-    ReplacementPolicy,
 )
 from core.mirror import MirrorUploader
+from coverage_utils import MetadataWranglerReplacementPolicy
 
 
 class WorkPresentationCoverageProvider(WorkCoverageProvider):
@@ -143,10 +143,7 @@ class IntegrationClientCoverImageCoverageProvider(CatalogCoverageProvider,
 
         replacement_policy = kwargs.pop('replacement_policy', None)
         if not replacement_policy:
-            mirror = MirrorUploader.sitewide(_db)
-            replacement_policy = ReplacementPolicy(
-                mirror=mirror, links=True
-            )
+            replacement_policy = MetadataWranglerReplacementPolicy.from_db(_db)
 
         # Only process identifiers that have been registered for coverage.
         kwargs['registered_only'] = kwargs.get('registered_only', True)

--- a/overdrive.py
+++ b/overdrive.py
@@ -10,7 +10,6 @@ from core.model import (
     ExternalIntegration,
     Identifier,
 )
-from core.metadata_layer import ReplacementPolicy
 from core.overdrive import (
     OverdriveBibliographicCoverageProvider as BaseOverdriveBibliographicCoverageProvider,
     OverdriveAPI

--- a/problem_details.py
+++ b/problem_details.py
@@ -21,3 +21,10 @@ INVALID_INTEGRATION_DOCUMENT = pd(
     400,
     title=_("Invalid integration document")
 )
+
+DISABLED_CLIENT = pd(
+    "http://librarysimplified.org/terms/problem/client-disabled",
+    403,
+    _("Disabled client"),
+    _("This client's access to the metadata wrangler has been disabled. Please contact the server administrator to work this out."),
+)

--- a/tests/oclc_/test_linked_data.py
+++ b/tests/oclc_/test_linked_data.py
@@ -180,7 +180,8 @@ class TestLinkedDataCoverageProvider(DatabaseTest):
     def test_set_equivalence(self):
         edition = self._edition()
         edition.title = "The House on Mango Street"
-        edition.add_contributor(Contributor(viaf="112460612"), Contributor.AUTHOR_ROLE)
+        contributor, ignore = self._contributor(viaf="112460612")
+        edition.add_contributor(contributor, Contributor.AUTHOR_ROLE)
         identifier = edition.primary_identifier
 
         i1 = self._identifier()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -162,6 +162,14 @@ class TestMetadataWrangler(ControllerTest):
         eq_(result, self.client)
         eq_(self.client, flask.request.authenticated_client)
 
+    @authenticated_request_context
+    def test_disabled_client(self):
+        self.client.enabled = False
+        # If the credentials are valid but the IntegrationClient is
+        # disabled, DISABLED_CLIENT is returned.
+        result = MetadataWrangler.authenticated_client_from_request(self._db)
+        eq_(DISABLED_CLIENT, result)
+
     def test_invalid_authentication(self):
         # If the credentials are missing or invalid, but
         # authentication is required, a ProblemDetail is returned.

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -9,6 +9,7 @@ from core.model import (
     CoverageRecord,
     DataSource,
     ExternalIntegration,
+    ExternalIntegrationLink,
 )
 
 from core.s3 import S3Uploader
@@ -71,7 +72,7 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
 
         # Since no storage integration is configured, we will not be mirroring
         # content anywhere.
-        eq_(None, policy.mirror)
+        assert all([x == None for x in policy.mirrors.values()])
 
         # A VIAFClient was instantiated as well.
         assert isinstance(provider.viaf, VIAFClient)
@@ -93,8 +94,9 @@ class TestIdentifierResolutionCoverageProvider(DatabaseTest):
         # and stored in the ReplacementPolicy used by this
         # CoverageProvider.
         policy = provider.replacement_policy
-        assert isinstance(policy.mirror, S3Uploader)
-        eq_("b", policy.mirror.client._request_signer._credentials.secret_key)
+
+        mirror = policy.mirrors[ExternalIntegrationLink.COVERS]
+        assert isinstance(mirror, S3Uploader)
 
     def test_unaffiliated_collection(self):
         """A special collection exists to track Identifiers not affiliated

--- a/tests/test_integration_client.py
+++ b/tests/test_integration_client.py
@@ -9,7 +9,6 @@ from . import (
 )
 
 from core.coverage import CoverageFailure
-from core.metadata_layer import ReplacementPolicy
 from core.model import (
     CoverageRecord,
     ExternalIntegration,
@@ -19,6 +18,7 @@ from core.model import (
 from core.s3 import MockS3Uploader
 from core.testing import AlwaysSuccessfulCoverageProvider
 
+from coverage_utils import MetadataWranglerReplacementPolicy
 from integration_client import (
     CalculatesWorkPresentation,
     IntegrationClientCoverImageCoverageProvider,
@@ -155,8 +155,8 @@ class TestIntegrationClientCoverImageCoverageProvider(DatabaseTest):
     def setup(self):
         super(TestIntegrationClientCoverImageCoverageProvider, self).setup()
         mirror = MockS3Uploader()
-        replacement_policy = ReplacementPolicy.from_metadata_source(
-            mirror=mirror
+        replacement_policy = MetadataWranglerReplacementPolicy.from_db(
+            self._db, mirror=mirror
         )
         self.collection = self._collection(
             protocol=ExternalIntegration.OPDS_FOR_DISTRIBUTORS

--- a/tests/test_integration_client.py
+++ b/tests/test_integration_client.py
@@ -166,6 +166,22 @@ class TestIntegrationClientCoverImageCoverageProvider(DatabaseTest):
             replacement_policy=replacement_policy, collection=self.collection
         )
 
+    def test_default_replacement_policy(self):
+        # In setup() we provide a replacement policy for use in the
+        # test.  If you don't provide a replacement policy, a
+        # MetadataWranglerReplacementPolicy is automatically created.
+        provider = IntegrationClientCoverImageCoverageProvider(
+            collection=self.collection
+        )
+        assert isinstance(
+            provider.replacement_policy, MetadataWranglerReplacementPolicy
+        )
+
+        # Verify that links are replaced. This automatically happens
+        # because of the from_metadata_source() call but we test it
+        # because we used to have code that explicitly set this.
+        eq_(True, provider.replacement_policy.links)
+
     def test_data_source_is_collection_specific(self):
         eq_(self.collection.name, self.provider.data_source.name)
 


### PR DESCRIPTION
This branch implements https://jira.nypl.org/browse/SIMPLY-2418 by allowing the metadata wrangler to keep track of certain integration clients that it just won't allow to use the site. The goal here is to stop servers with known problems (such as https://jira.nypl.org/browse/SIMPLY-2266) from bringing down the metadata wrangler.

We don't have an interface for enabling or disabling these clients, but it shouldn't be an issue -- we shouldn't need to do this a whole lot.