### PR TITLE
Peg nltk to the final Python 2 release.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ textblob
 ndg-httpsclient
 
 # Used only by metadata
-pyld
+pyld==1.0.5
 beautifulsoup4
 zeep
 py-bcrypt

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ urllib3<1.24 # Travis problem introduced 20181016 - check to see when we can rem
 lxml
 flask
 flask-sqlalchemy-session
-textblob
 isbnlib
 feedparser
 uwsgi
@@ -26,6 +25,10 @@ pymarc
 accept-types
 watchtower # for cloudwatch logging
 pyspellchecker
+
+# nltk is a textblob dependency, and this is the last release that supports Python 2
+nltk==3.4.5
+textblob
 
 # Ensure that we support SNI-based SSL
 ndg-httpsclient


### PR DESCRIPTION
Metadata version of https://github.com/NYPL-Simplified/server_core/pull/1173.

NLTK 3.4.5 was [the final release to support Python 2](https://www.nltk.org/news.html). A Python 3-only release was put out early this week, and now anyone who tries to set up a circ manager will get a release of NLTK that won't work, installed as a dependency on textblob. This branch pegs the version of NLTK in use to the final Python 2 release.

Ticket: https://jira.nypl.org/browse/SIMPLY-2705

This branch does not update the core submodule or make any other changes; it only changes the requirements.txt.

On metadata, we have a second dependency which recently went Python 3-only: PyLD.