### PR TITLE
Py3 updated core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 language: python
 
 python:
-  - "2.7"
+  - "3.6"
 
 cache: pip
 

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ from nose.tools import set_trace
 import os
 import logging
 import sys
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from flask import Flask
 from flask_babel import Babel

--- a/controller.py
+++ b/controller.py
@@ -17,7 +17,7 @@ import feedparser
 import json
 import jwt
 import logging
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from core.app_server import (
     cdn_url_for,
@@ -127,8 +127,11 @@ class MetadataWrangler(object):
 
             # We can hopefully use the provided bearer token to
             # authenticate an IntegrationClient.
+            shared_secret = None
             try:
                 shared_secret = base64.b64decode(header.split(' ')[1])
+            except stdlib_base64.binascii.Error as e:
+                return INVALID_CREDENTIALS
             except TypeError as e:
                 # The bearer token is ill-formed.
                 return INVALID_CREDENTIALS
@@ -867,7 +870,7 @@ class IntegrationClientController(Controller):
 
         submitted_secret = None
         auth_header = flask.request.headers.get('Authorization')
-        if auth_header and isinstance(auth_header, basestring) and 'bearer' in auth_header.lower():
+        if auth_header and isinstance(auth_header, str) and 'bearer' in auth_header.lower():
             token = auth_header.split(' ')[1]
             submitted_secret = base64.b64decode(token)
 

--- a/fast.py
+++ b/fast.py
@@ -7,7 +7,7 @@ This is how we know, e.g. that FAST classification 1750175 means
 from contextlib import contextmanager
 import gzip
 import csv
-from io import BytesIO
+from io import StringIO
 import logging
 import os
 import re
@@ -63,7 +63,7 @@ class FASTNames(dict):
         """Load classifications from an N-Triples file."""
         if path.endswith(".nt.gz"):
             # This is a single GZipped N-Triples file.
-            self.load_triples_filehandle(gzip.open(path, 'rb'))
+            self.load_triples_filehandle(gzip.open(path, 'rt', encoding="utf-8"))
         elif path.endswith(".nt.zip"):
             # This is a ZIP file containing one or more (probably just
             # one) N-Triples files. Load each one the zip.
@@ -77,12 +77,12 @@ class FASTNames(dict):
         """Open up `path` as a ZIP file and find one or more (probably just
         one) N-Triples files inside.
 
-        :yield: A BytesIO for each N-Triples file in the ZIP.
+        :yield: A StringIO for each N-Triples file in the ZIP.
         """
-        with zipfile.ZipFile(path) as archive:
+        with zipfile.ZipFile(path, mode="r") as archive:
             for name in archive.namelist():
                 if name.endswith(".nt"):
-                    yield BytesIO(archive.read(name))
+                    yield StringIO(archive.read(name).decode("utf-8"))
 
     def load_triples_filehandle(self, fh):
         """Load a number of N-Triples from a filehandle, and
@@ -112,7 +112,7 @@ class FASTNames(dict):
             "Reading cached %s names from %s", cls.SUBDIR, path
         )
         names = cls()
-        fh = gzip.open(path, 'rb')
+        fh = gzip.open(path, 'rt', encoding="utf-8")
         reader = csv.reader(fh)
         for identifier, name in reader:
             names[identifier] = name
@@ -124,16 +124,16 @@ class FASTNames(dict):
         """
         with self.consolidated_output_filehandle(path) as output:
             writer = csv.writer(output)
-            for k,v in list(self.items()):
+            for k, v in list(self.items()):
                 writer.writerow([k, v])
 
     @contextmanager
     def consolidated_output_filehandle(self, path):
         """Open a write filehandle to the given path.
-
         This method is designed to be mocked in unit tests.
         """
-        with gzip.open(path, "wb") as out:
+        with gzip.open(path, "w") as out:
+            set_trace()
             yield out
 
 

--- a/oclc/classify.py
+++ b/oclc/classify.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from lxml import etree
 from nose.tools import set_trace

--- a/oclc/linked_data.py
+++ b/oclc/linked_data.py
@@ -64,17 +64,17 @@ class ldq(object):
 
     @classmethod
     def restrict_to_language(self, values, code_2):
-        if isinstance(values, (unicode, dict)):
+        if isinstance(values, (str, dict)):
             values = [values]
         for v in values:
-            if isinstance(v, unicode):
+            if isinstance(v, str):
                 yield v
             elif v and (not '@language' in v or v['@language'] == code_2):
                 yield v
 
     @classmethod
     def values(self, vs):
-        if isinstance(vs, unicode):
+        if isinstance(vs, str):
             yield vs
             return
         if isinstance(vs, dict) and '@value' in vs:
@@ -82,7 +82,7 @@ class ldq(object):
             return
 
         for v in vs:
-            if isinstance(v, unicode):
+            if isinstance(v, str):
                 yield v
             elif '@value' in v:
                 yield v['@value']
@@ -155,7 +155,7 @@ class OCLCLinkedData(object):
     POINTLESS_TAGS = set([
         'large type', 'large print', '(binding)', 'movable books',
         'electronic books', 'braille books', 'board books',
-        'electronic resource', u'états-unis', 'etats-unis',
+        'electronic resource', 'états-unis', 'etats-unis',
         'ebooks',
     ])
 
@@ -189,7 +189,7 @@ class OCLCLinkedData(object):
         identifier = None
         if isinstance(identifier_or_uri, bytes):
             identifier_or_uri = identifier_or_uri.decode("utf8")
-        if isinstance(identifier_or_uri, unicode):
+        if isinstance(identifier_or_uri, str):
             # e.g. http://experiment.worldcat.org/oclc/1862341597.json
             match = self.URI_WITH_OCLC_NUMBER.search(identifier_or_uri)
             if match:
@@ -374,7 +374,7 @@ class OCLCLinkedData(object):
             # a single name. (This is really fun, of course!)
             names = list()
             for name in name_list:
-                if isinstance(name, unicode):
+                if isinstance(name, str):
                     names.append(name)
                 if isinstance(name, dict):
                     more_names = list(ldq.restrict_to_language(name, 'en'))
@@ -443,7 +443,7 @@ class OCLCLinkedData(object):
             if isinstance(name_obj, dict):
                 if name_obj.get('@language', None) == 'en':
                     name_obj = name_obj.get('@value', None)
-            if isinstance(name_obj, unicode):
+            if isinstance(name_obj, str):
                 # Sometimes names in character-based languages are included,
                 # without indication. They're being removed below by ensuring
                 # some number of alphanumeric are present.
@@ -526,7 +526,7 @@ class OCLCLinkedData(object):
         subjects[Subject.TAG] = [dict(id=genre) for genre in genres]
 
         for uri in book.get('about', []):
-            if not isinstance(uri, unicode):
+            if not isinstance(uri, str):
                 continue
 
             subject_id = subject_type = subject_name = None
@@ -559,7 +559,7 @@ class OCLCLinkedData(object):
                     for potential_type in potential_types:
                         if isinstance(potential_type, dict):
                             type_objs.append(potential_type)
-                        elif isinstance(potential_type, unicode):
+                        elif isinstance(potential_type, str):
                             type_objs.append({'@id': potential_type})
                 for type_obj in type_objs:
                     type_id = type_obj['@id']
@@ -759,7 +759,7 @@ class OCLCLinkedData(object):
             for this_type_obj in these_type_objs:
                 if isinstance(this_type_obj, dict):
                     type_objs.append(this_type_obj)
-                elif isinstance(this_type_obj, unicode):
+                elif isinstance(this_type_obj, str):
                     type_objs.append({"@id": this_type_obj})
         types = [i['@id'] for i in type_objs if
                  i['@id'] not in self.UNUSED_TYPES]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ beautifulsoup4==4.9.1
 cairosvg==1.0.22
 # Ensure that we support SNI-based SSL
 ndg-httpsclient==0.5.1
-pycrypto
+pycrypto==2.6.1
 PyJWT==1.4.2
 # Used only by metadata
 PyLD==1.0.5

--- a/shadow_catalog.py
+++ b/shadow_catalog.py
@@ -150,7 +150,7 @@ class MarcTag(object):
 
 class Representation(object):
 
-    from collections import Counter
+    from .collections import Counter
     tag_type = Counter()
 
     @classmethod

--- a/tests/oclc_/test_linked_data.py
+++ b/tests/oclc_/test_linked_data.py
@@ -99,7 +99,7 @@ class TestOCLCLinkedData(DatabaseTest):
 
         eq_(Identifier.OCLC_NUMBER, oclc_id_type)
         eq_("11866009", oclc_id)
-        eq_([u"Galápagos : a novel"], titles)
+        eq_(["Galápagos : a novel"], titles)
         eq_(1, len(descriptions))
 
         # Even though there are 11 links in the books "about" list,
@@ -134,7 +134,7 @@ class TestOCLCLinkedData(DatabaseTest):
         eq_("11866009", metadata_obj.primary_identifier.identifier)
 
         # It has publication information & ISBNs
-        eq_(u"Galápagos : a novel", metadata_obj.title)
+        eq_("Galápagos : a novel", metadata_obj.title)
         eq_('Delacorte Press/Seymour Lawrence', metadata_obj.publisher)
         eq_(1985, metadata_obj.published.year)
         eq_(1, len(metadata_obj.links))
@@ -280,7 +280,7 @@ class TestLinkedDataCoverageProvider(DatabaseTest):
             DataSource.OCLC_LINKED_DATA,
             contributors=[contributor1, contributor2, contributor3],
             primary_identifier=idata,
-            title=u"foo"
+            title="foo"
         )
         oclc.queue_info_for(metadata)
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -466,7 +466,7 @@ class TestCatalogController(ControllerTest):
             )
 
         # The feed has the expected links.
-        links = feedparser.parse(unicode(feed)).feed.links
+        links = feedparser.parse(str(feed)).feed.links
         eq_(2, len(links))
         eq_(['next', 'self'], sorted([l.rel for l in links]))
         [next_href] = [l.href for l in links if l.rel=='next']
@@ -485,7 +485,7 @@ class TestCatalogController(ControllerTest):
                 thing='whatever'
             )
 
-        links = feedparser.parse(unicode(feed)).feed.links
+        links = feedparser.parse(str(feed)).feed.links
         eq_(3, len(links))
         eq_(['first', 'previous', 'self'], sorted([l.rel for l in links]))
 

--- a/tests/test_coverage_utils.py
+++ b/tests/test_coverage_utils.py
@@ -194,7 +194,7 @@ class TestResolveVIAFOnSuccessCoverageProvider(DatabaseTest):
         provider = MockResolveVIAF(self._default_collection)
 
     def test_handle_success_failures(self):
-        """Test failures that can happen during handle_success."""
+        # Test failures that can happen during handle_success.
 
         class Mock(MockResolveVIAF):
             def resolve_viaf(self, work):

--- a/tests/test_fast.py
+++ b/tests/test_fast.py
@@ -3,7 +3,7 @@ from nose.tools import (
     set_trace,
 )
 from contextlib import contextmanager
-from io import BytesIO
+from io import StringIO
 import os
 
 from fast import (
@@ -15,7 +15,7 @@ BASE_DIR = os.path.split(__file__)[0]
 
 class MockFASTNames(FASTNames):
     """Works just like FASTNames, but writes consolidated output to a
-    BytesIO object rather than a file on disk.
+    String object rather than a file on disk.
     """
 
     def __init__(self):
@@ -23,15 +23,15 @@ class MockFASTNames(FASTNames):
 
     @contextmanager
     def consolidated_output_filehandle(self, path):
-        # Create a BytesIO object to stand in for the
+        # Create a String object to stand in for the
         # consolidated file that would otherwise be written to
         # disk.
-        self.output_consolidated_file = BytesIO()
+        self.output_consolidated_file = StringIO()
         yield self.output_consolidated_file
 
 class MockLCSHNames(MockFASTNames, LCSHNames):
     """Works just like LCSHNames, but writes consolidated output to a
-    BytesIO object rather than a file on disk.
+    StringIO object rather than a file on disk.
     """
 
 class TestFASTNames(object):
@@ -53,7 +53,7 @@ class TestFASTNames(object):
         
         # A consolidated file was written to "disk" in CSV format.
         output = not_consolidated.output_consolidated_file
-        expect = '1726280,Filmed roundtables\r\n631903,New Yorker (Fireboat)\r\n1750175,"Short stories, American"\r\n'
+        expect = '631903,New Yorker (Fireboat)\r\n1750175,"Short stories, American"\r\n1726280,Filmed roundtables\r\n'
         eq_(expect, output.getvalue())
 
     def test_from_data_directory_consolidated(self):

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -3,7 +3,7 @@ from nose.tools import (
     eq_,
     set_trace,
 )
-import urllib
+import urllib.request, urllib.parse, urllib.error
 from core.metadata_layer import ReplacementPolicy
 from core.s3 import MockS3Uploader
 from core.testing import (
@@ -82,7 +82,7 @@ class TestOverdriveBibliographicCoverageProvider(DatabaseTest):
         # URLs.
         expect = "Overdrive/Overdrive ID/%s" % identifier.identifier
         for url in [full.mirror_url, thumbnail.mirror_url]:
-            assert urllib.quote(expect) in url
+            assert urllib.parse.quote(expect) in url
         assert "/scaled/" in thumbnail.mirror_url
         assert "/scaled/" not in full.mirror_url
 


### PR DESCRIPTION
This PR adds on to the existing python 3 PR.
* This uses the updated python 3 `server_core` submodule.
* Removes `six`.
* Converts other files that weren't converted before.
* The biggest update is in the `fast.py` file. In python 3, the csv package expects text mode input rather than binary, so how gzip and zip files are opened changed --  [this](https://stackoverflow.com/questions/8515053/csv-error-iterator-should-return-strings-not-bytes) and [this](https://stackoverflow.com/questions/34283178/typeerror-a-bytes-like-object-is-required-not-str-in-python-and-csv) were helpful.

There's still updating and using Docker to deploy and updating tests to pytests but will hold off on that to work on `circulation` first. Just wanted to get this at a stable python 3 base.