### PR TITLE
Docker update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,28 @@
 # Library Simplified Metadata Wrangler
 [![Build Status](https://api.travis-ci.com/NYPL-Simplified/metadata_wrangler.svg?branch=master)](https://travis-ci.com/github/NYPL-Simplified/metadata_wrangler)
 
-This is the Metadata Wrangler for [Library Simplified](https://librarysimplified.org/). The metadata server utilizes and intelligently amalgamates a wide variety of information sources for library ebooks and incorporates them into the reading experience for users by improving selection, search, and recommendations.
+This is the Metadata Wrangler for [Library Simplified](https://librarysimplified.org/). The Metadata Wrangler server utilizes and intelligently amalgamates a wide variety of information sources for library ebooks and incorporates them into the reading experience for users by improving selection, search, and recommendations.
 
-It depends on the [LS Server Core](https://github.com/NYPL-Simplified/server_core) as a git submodule.
+This application depends on [Library Simplified Server Core](https://github.com/NYPL-Simplified/server_core) as a git submodule.
 
-## Installation
+## Local Installation
 
 Thorough deployment instructions, including essential libraries for Linux systems, can be found [in the Library Simplified wiki](https://github.com/NYPL-Simplified/Simplified/wiki/Deployment-Instructions). **_If this is your first time installing a Library Simplified server, please review those instructions._**
 
-Keep in mind that the metadata server requires unique database names and a data directory, as detailed below.
+Keep in mind that the Metadata Wrangler server requires unique database names and a data directory, as detailed below.
+
+Once the database is running, run the application locally with `python app.py` and go to `http://localhost:7000`. If you rather run this server locally through Docker, read the "Docker" section below, though this option doesn't currently allow for local development.
 
 ### Database
 
-Create relevant databases in Postgres:
+When installing and running a local Metadata Wrangler, you need to create the relevant databases in Postgres. If you are using Docker, you can skip this step since the Postgres database will be created in a container.
+
 ```sh
 $ sudo -u postgres psql
-CREATE DATABASE simplified_metadata_test;
 CREATE DATABASE simplified_metadata_dev;
+CREATE DATABASE simplified_metadata_test;
 
-# Create users, unless you've already created them for another LS project
+# Create users, unless you've already created them for another Library Simplified project
 CREATE USER simplified with password '[password]';
 CREATE USER simplified_test with password '[password]';
 
@@ -37,15 +40,24 @@ $ git clone https://github.com/NYPL-Simplified/data.git YOUR_DATA_DIRECTORY
 In your content server configuration file, your specified "data_directory" should be YOUR_DATA_DIRECTORY.
 
 ## Testing
-The github actions CI service runs the unit tests against Python 3.6, 3.7, 3.8 and 3.9 automatically using [tox](https://tox.readthedocs.io/en/latest/). 
 
-To run `pytest` unit tests locally, install `tox`.
+The Github Actions CI service runs the pytest unit tests against Python 3.6, 3.7, 3.8 and 3.9 automatically using [tox](https://tox.readthedocs.io/en/latest/).
+
+To run `pytest` unit tests locally, install `tox`. Make sure you're in the current virtual environment. 
 
 ```
-pip install tox
+$ pip install tox
 ```
 
-Tox has an environment for each python version and an optional `-docker` factor that will automatically use docker to deploy service containers used for the tests. You can select the environment you would like to test with the tox `-e` flag.
+Then run `tox` to run the pytests in all Python versions. 
+
+```
+$ tox
+```
+
+This uses the local Postgres database by default so that service should be running. If you rather depend on using Docker to spin up a Postgres container for testing, read more in the "Testing with Docker" section below.
+
+Tox has an environment for each python version and an optional `-docker` factor that will automatically use docker to deploy service containers used for the tests. You can select the environment you would like to test with the tox `-e` flag. More on this in the following sections.
 
 ### Environments
 
@@ -58,7 +70,7 @@ Tox has an environment for each python version and an optional `-docker` factor 
 
 All of these environments are tested by default when running tox. To test one specific environment you can use the `-e` flag.
 
-Test Python 3.8, for example:
+To run pytest only with Python 3.8, for example, run:
 
 ```
 tox -e py38
@@ -68,46 +80,106 @@ You need to have the Python versions you are testing against installed on your l
 
 [Pyenv](https://github.com/pyenv/pyenv) is a useful tool to install multiple Python versions, if you need to install missing Python versions in your system for local testing.
 
-### Docker
+### Testing with Docker
 
-If you install `tox-docker`, tox will take care of setting up all the service containers necessary to run the unit tests and pass the correct environment variables to configure the tests to use these services. Using `tox-docker` is not required, but it is the recommended way to run the tests locally, since it runs the tests in the same way they are run on the Github Actions CI server. 
+If you install `tox-docker`, `tox` will take care of setting up all the service containers necessary to run the unit tests and pass the correct environment variables to configure the tests to use these services. Using `tox-docker` is not required, but it is the _recommended_ way to run the tests locally, since it runs the tests in the same way they are run on the Github Actions CI server. 
 
-```
-pip install tox-docker
+```sh
+$ pip install tox-docker
 ``` 
 
 The docker functionality is included in a `docker` factor that can be added to the environment. To run an environment
 with a particular factor you add it to the end of the environment. 
 
-Test with Python 3.8 using docker containers for the services.
-```
-tox -e py38-docker
+To test with Python 3.8 using docker containers for the services, run:
+
+```sh
+$ tox -e py38-docker
 ```
 
 ### Local services
 
-If you already have postgres running locally, you can run it instead by setting the following environment variable:
+If you already have Postgres running locally, you can use that service instead by setting the following environment variable:
 
 - `SIMPLIFIED_TEST_DATABASE`
 
 Make sure the ports and usernames are updated to reflect the local configuration.
-```
+
+```sh
 # Set environment variables
-export SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:9005/simplified_metadata_test"
+$ export SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:9005/simplified_metadata_test"
 
 # Run tox
-tox -e py38
+$ tox -e py38
 ```
 
 ### Override `pytest` arguments
 
-If you wish to pass additional arguments to `pytest` you can do so through `tox`. The default argument passed to `pytest` is `tests`, however you can override this. Every argument passed after a `--` to the `tox` command line will the passed to `pytest`, overriding the default.
+If you wish to pass additional arguments to `pytest` you can do so through `tox`. The default argument passed to `pytest` is `tests`, however you can override this. Every argument passed after a `--` to the `tox` command will then be passed to `pytest`, overriding the default.
 
-Only run the `test_cdn` tests with Python 3.6 using docker.
+For example, when you only want to test changes in one test file, you can pass the path to the file after `--`. To run the `test_content_cafe.py` tests with Python 3.6 using docker, run:
 
+```sh
+$ tox -e py36-docker -- tests/test_content_cafe.py
 ```
-tox -e py36-docker -- tests/test_cdn.py
-```  
+
+To run specific tests within a file, pass in the test class and the optional function name in the following format:
+
+```sh
+$ tox -e py36-docker -- tests/test_content_cafe.py::TestContentCafeAPI::test_from_config
+```
+
+## Docker
+
+Docker is used to run the application server, a scripts server, and a database in containers that communicate with each other. This allows for easy deployment but can't currently be used for local development. This is because the current installation script installs the repo by cloning it from Github, and not the current local file system.
+
+In the `/docker` directory, there are three `Dockerfile`s for each separate container service. Rather than running each container individually, use the `./docker-compose.yml` file and the `docker compose` command to orchestrate building and running the containers.
+
+_Note: The `docker compose` command is "experimental" but will become the default command to use `docker-compose.yml` files. The existing command line tool `docker-compose` is still supported if that tool is preferred. Just replace the following `docker compose` commands with `docker-compose`._
+
+### Running the Containers
+
+To build and start the three containers, run:
+
+```sh
+$ docker compose up -d
+```
+
+Once the base images are downloaded, the server images are built, and the servers are running, visit `http://localhost` for the Metadata Wrangler homepage. The `-d` flag runs the command in "detached" mode so they will run in the background. If you need to rebuild the images, add the `--build` flag.
+
+It's possible to stop running the containers but not to remove them using:
+
+```sh
+$ docker compose stop
+```
+
+You can re-start the existing containers with:
+
+```sh
+$ docker compose start
+```
+
+If you want to stop _and_ remove the containers, run:
+
+```sh
+$ docker compose down
+```
+
+### Debugging Local Containers
+
+It's possible to get access to a container to see local files and logs. First, find the container ID of the service you want to get access to. The following command will list all containers, running and stopped, on the machine:
+
+```sh
+$ docker ps --all
+```
+
+This will return a list of containers and the relevant containers created by this repo's `docker-compose.yml` file will be "metadata_wrangler_scripts", "metadata_wrangler_webapp", and "postgres12.0-alpine". Once you get the "Container ID" of the service you want access to, for example `56dcb9e3da3b`, run:
+
+```sh
+$ docker exec -it 56dcb9e3da3b bash
+```
+
+This will give you bash access to the container to find logs, located at the given directory for each container's `volumes` directory configuration in `docker-compose.yml`. To exit, run `exit`.
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   db:
-    image: "postgres:9.5"
+    image: "postgres:9.6"
     environment:
       POSTGRES_PASSWORD: "password"
       POSTGRES_USER: "simplified"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 version: '3.6'
 services:
   db:
-    image: "postgres:9.6"
+    image: "postgres:12.0-alpine"
     environment:
       POSTGRES_PASSWORD: "password"
       POSTGRES_USER: "simplified"
       POSTGRES_DB: "simplified_metadata_dev"
+    ports:
+      - 5432:5432/tcp
     volumes:
       - "dbdata:/var/lib/postgresql/data"
 

--- a/docker/Dockerfile.exec
+++ b/docker/Dockerfile.exec
@@ -1,5 +1,5 @@
 FROM phusion/baseimage:bionic-1.0.0
-MAINTAINER Library Simplified <info@librarysimplified.org>
+LABEL maintainer="Library Simplified <info@librarysimplified.org>"
 
 ARG version
 ARG repo="NYPL-Simplified/metadata_wrangler"

--- a/docker/Dockerfile.exec
+++ b/docker/Dockerfile.exec
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:bionic-1.0.0
 MAINTAINER Library Simplified <info@librarysimplified.org>
 
 ARG version

--- a/docker/Dockerfile.scripts
+++ b/docker/Dockerfile.scripts
@@ -1,11 +1,11 @@
 FROM phusion/baseimage:bionic-1.0.0
-MAINTAINER Library Simplified <info@librarysimplified.org>
+LABEL maintainer="Library Simplified <info@librarysimplified.org>"
 
 ARG version
 ARG repo="NYPL-Simplified/metadata_wrangler"
 
 ENV SIMPLIFIED_DB_TASK "auto"
-
+# Set the local timezone in /docker/simplified_cron.sh
 ENV TZ=US/Eastern
 
 # Copy over all Library Simplified build files for this image

--- a/docker/Dockerfile.scripts
+++ b/docker/Dockerfile.scripts
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:bionic-1.0.0
 MAINTAINER Library Simplified <info@librarysimplified.org>
 
 ARG version

--- a/docker/Dockerfile.webapp
+++ b/docker/Dockerfile.webapp
@@ -1,5 +1,5 @@
 FROM phusion/baseimage:bionic-1.0.0
-MAINTAINER Library Simplified <info@librarysimplified.org>
+LABEL maintainer="Library Simplified <info@librarysimplified.org>"
 
 ARG version
 ARG repo="NYPL-Simplified/metadata_wrangler"
@@ -21,6 +21,6 @@ EXPOSE 80
 
 CMD ["/sbin/my_init"]
 
-# # If you launch the container interactively with `docker run -it`,
-# # this is where you'll end up:
+# If you launch the container interactively with `docker run -it`,
+# this is where you'll end up:
 # ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile.webapp
+++ b/docker/Dockerfile.webapp
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:bionic-1.0.0
 MAINTAINER Library Simplified <info@librarysimplified.org>
 
 ARG version

--- a/docker/simplified_app.sh
+++ b/docker/simplified_app.sh
@@ -31,15 +31,11 @@ mkdir /var/www && cd /var/www
 git clone https://github.com/${repo}.git metadata
 chown simplified:simplified metadata 
 cd metadata
-# git checkout $version
-# Temporary:
-git checkout "py3-base"
+git checkout $version
 
 # Use https to access submodules.
 git config submodule.core.url https://github.com/NYPL-Simplified/server_core.git
 git submodule update --init --recursive
-# Temporary:
-cd core && git checkout "py3-base" && cd ..
 
 # Add a .version file to the directory. This file
 # supplies an endpoint to check the app's current version.
@@ -56,7 +52,9 @@ echo "if [[ -f $SIMPLIFIED_ENVIRONMENT ]]; then \
 # Install required python libraries.
 set +x && source env/bin/activate && set -x
 
+# Update pip and setuptools.
 python3 -m pip install -U pip setuptools
+# Install the necessary dev requirements.
 python3 -m pip install -r requirements-dev.txt
 
 # Install NLTK.

--- a/docker/startup/02_manage_simplified_database.sh
+++ b/docker/startup/02_manage_simplified_database.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# Manages the Metadata Wrangler database (either initializing it, migrating
-# it, or ignoring it) when the container starts and before the app launches.
+# Manages the Metadata Wrangler database by either initializing it, migrating
+# it, or ignoring it when the container starts and before the app launches.
+# The $SIMPLIFIED_DB_TASK variable is set in the each of the container's
+# Dockerfiles.
 
 set -ex
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ allowlist_externals =
     python
 
 [docker:db]
-image = postgres:9.6
+image = postgres:12
 environment =
     POSTGRES_USER=simplified_test
     POSTGRES_PASSWORD=test


### PR DESCRIPTION
Resolves [SIMPLY-3541](https://jira.nypl.org/browse/SIMPLY-3541).

This is branched off the `datetime-update` branch.

This PR implements the minimum to get Docker to run the application in python 3. This also updates the Postgres database from 9.5 to 12 in Docker and in tox that runs pytests.

I updated the README regarding running the application locally with and without Docker. One limitation of using Docker is that it's meant for deployment only and not for local development. Since I just wanted to get this working with python 3 and not add any new features, this would be great to look into in the future. It may be as simple as mounting the current directory with the directory the webapp docker container uses.